### PR TITLE
[ADD] Routine 엔티티 구체화

### DIFF
--- a/src/main/java/com/soptie/server/member/entity/Member.java
+++ b/src/main/java/com/soptie/server/member/entity/Member.java
@@ -8,7 +8,6 @@ import com.soptie.server.common.entity.BaseTime;
 import com.soptie.server.memberDoll.entity.MemberDoll;
 import com.soptie.server.memberRoutine.entity.MemberDailyRoutine;
 import com.soptie.server.memberRoutine.entity.MemberHappinessRoutine;
-import com.soptie.server.routine.entity.daily.DailyTheme;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -21,10 +20,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor
+@Getter
 public class Member extends BaseTime {
 
 	@Id
@@ -42,7 +43,7 @@ public class Member extends BaseTime {
 
 	@Column(columnDefinition = "TEXT", nullable = false)
 	@Convert(converter = StringListConverter.class)
-	private List<DailyTheme> themes;
+	private List<String> themes;
 
 	@OneToOne
 	@JoinColumn(name = "doll_id")
@@ -54,4 +55,12 @@ public class Member extends BaseTime {
 	@OneToOne
 	@JoinColumn(name = "happiness_routine_id")
 	private MemberHappinessRoutine happinessRoutine;
+
+	public void initHappinessRoutine() {
+		this.happinessRoutine = null;
+	}
+
+	public void addHappinessRoutine(MemberHappinessRoutine happinessRoutine) {
+		this.happinessRoutine = happinessRoutine;
+	}
 }

--- a/src/main/java/com/soptie/server/memberRoutine/entity/MemberDailyRoutine.java
+++ b/src/main/java/com/soptie/server/memberRoutine/entity/MemberDailyRoutine.java
@@ -1,5 +1,7 @@
 package com.soptie.server.memberRoutine.entity;
 
+import java.util.Objects;
+
 import com.soptie.server.member.entity.Member;
 import com.soptie.server.routine.entity.daily.DailyRoutine;
 
@@ -33,4 +35,19 @@ public class MemberDailyRoutine {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "routine_id")
 	private DailyRoutine routine;
+
+	public MemberDailyRoutine(Member member, DailyRoutine routine) {
+		this.achieveCount = 0;
+		this.isAchieve = false;
+		setMember(member);
+		this.routine = routine;
+	}
+
+	private void setMember(Member member) {
+		if (Objects.nonNull(this.member)) {
+			this.member.getDailyRoutines().remove(this);
+		}
+		this.member = member;
+		member.getDailyRoutines().add(this);
+	}
 }

--- a/src/main/java/com/soptie/server/memberRoutine/entity/MemberHappinessRoutine.java
+++ b/src/main/java/com/soptie/server/memberRoutine/entity/MemberHappinessRoutine.java
@@ -1,5 +1,7 @@
 package com.soptie.server.memberRoutine.entity;
 
+import java.util.Objects;
+
 import com.soptie.server.member.entity.Member;
 import com.soptie.server.routine.entity.happiness.HappinessSubRoutine;
 
@@ -29,4 +31,17 @@ public class MemberHappinessRoutine {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "routine_id")
 	private HappinessSubRoutine routine;
+
+	public MemberHappinessRoutine(Member member, HappinessSubRoutine routine) {
+		setMember(member);
+		this.routine = routine;
+	}
+
+	private void setMember(Member member) {
+		if (Objects.nonNull(this.member)) {
+			this.member.initHappinessRoutine();
+		}
+		this.member = member;
+		member.addHappinessRoutine(this);
+	}
 }

--- a/src/main/java/com/soptie/server/routine/entity/daily/DailyRoutine.java
+++ b/src/main/java/com/soptie/server/routine/entity/daily/DailyRoutine.java
@@ -4,9 +4,12 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -18,10 +21,10 @@ public class DailyRoutine {
 	@Column(name = "routine_id")
 	private Long id;
 
+	@Column(nullable = false)
 	private String content;
 
-	@Enumerated(value = EnumType.STRING)
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "theme_id")
 	private DailyTheme theme;
-
-	private String imageUrl;
 }

--- a/src/main/java/com/soptie/server/routine/entity/daily/DailyTheme.java
+++ b/src/main/java/com/soptie/server/routine/entity/daily/DailyTheme.java
@@ -1,4 +1,23 @@
 package com.soptie.server.routine.entity.daily;
 
-public enum DailyTheme {
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+public class DailyTheme {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "theme_id")
+	private Long id;
+
+	@Column(nullable = false)
+	private String name;
+
+	private String imageUrl;
 }

--- a/src/main/java/com/soptie/server/routine/entity/happiness/HappinessRoutine.java
+++ b/src/main/java/com/soptie/server/routine/entity/happiness/HappinessRoutine.java
@@ -21,6 +21,7 @@ public class HappinessRoutine {
 	@Enumerated(value = EnumType.STRING)
 	private HappinessTheme theme;
 
+	@Column(nullable = false)
 	private String title;
 
 	private String imageUrl;

--- a/src/main/java/com/soptie/server/routine/entity/happiness/HappinessSubRoutine.java
+++ b/src/main/java/com/soptie/server/routine/entity/happiness/HappinessSubRoutine.java
@@ -20,8 +20,10 @@ public class HappinessSubRoutine {
 	@Column(name = "sub_routine_id")
 	private Long id;
 
+	@Column(nullable = false)
 	private String content;
 
+	@Column(columnDefinition = "TEXT")
 	private String detailContent;
 
 	@ManyToOne

--- a/src/main/java/com/soptie/server/routine/entity/happiness/HappinessTheme.java
+++ b/src/main/java/com/soptie/server/routine/entity/happiness/HappinessTheme.java
@@ -1,4 +1,24 @@
 package com.soptie.server.routine.entity.happiness;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum HappinessTheme {
+	CLOSER_TO_ME("나와 더 가까워지기💖"),
+	ACHIEVEMENT("소소한 성취감🌻"),
+	START_OF_DAY("하루의 시작☀️"),
+	HEALTHY("건강한 몸💪"),
+	SLEEP("편안함 잠🍀"),
+	GRATEFUL_HEART("감사한 마음📮"),
+	KINDNESS("더 친절해지기👨‍👩‍👧‍👦"),
+	CONSUMPTION("잘 벌고 잘 쓰기💵"),
+	ENVIRONMENT("환경🍃"),
+	EMPTY("비워내기🗑️"),
+	IMMERSION("몰입을 위한 준비🔥"),
+	OVERCOME_HELPLESSNESS("무기력 극복☔️"),
+	;
+
+	private final String name;
 }


### PR DESCRIPTION
### Issue
closed #2 

### Description
- Routine 편의 메소드 생성 중 필요하여 Member 엔티티 내 메소드 추가했습니다.
- DailyTheme를 ENUM에서 Entity 형식으로 변경함에 따라 Member.themes 칼럼을 일부 임시 수정했습니다.
- DailyTheme에서 이름, 내용, 이미지 url을 가지고 있어 Entity 타입으로 변환했습니다.
- 더미데이터를 제외한 Entity 내 생성자와 편의 메소드를 추가했습니다.
- 전체 Entity의 칼럼에 속성을 추가했습니다.
- HappinessTheme(행복루틴 테마)에 기획 문서를 참고하여 임의로 값을 추가해두었습니다.