### PR TITLE
[FEAT] 데일리 루틴 테마 리스트 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,12 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
     testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.18.2'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+    // queryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/soptie/server/common/config/JpaQueryFactoryConfig.java
+++ b/src/main/java/com/soptie/server/common/config/JpaQueryFactoryConfig.java
@@ -1,0 +1,17 @@
+package com.soptie.server.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+@Configuration
+public class JpaQueryFactoryConfig {
+
+	@Bean
+	JPAQueryFactory jpaQueryFactory(EntityManager em) {
+		return new JPAQueryFactory(em);
+	}
+}

--- a/src/main/java/com/soptie/server/common/dto/Response.java
+++ b/src/main/java/com/soptie/server/common/dto/Response.java
@@ -1,0 +1,20 @@
+package com.soptie.server.common.dto;
+
+public record Response(
+	boolean success,
+	String message,
+	Object data
+) {
+
+	public static Response success(String message, Object data) {
+		return new Response(true, message, data);
+	}
+
+	public static Response success(String message) {
+		return new Response(true, message, null);
+	}
+
+	public static Response fail(String message) {
+		return new Response(false, message, null);
+	}
+}

--- a/src/main/java/com/soptie/server/routine/controller/DailyRoutineController.java
+++ b/src/main/java/com/soptie/server/routine/controller/DailyRoutineController.java
@@ -1,0 +1,28 @@
+package com.soptie.server.routine.controller;
+
+import static com.soptie.server.common.dto.Response.*;
+import static com.soptie.server.routine.message.ResponseMessage.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.soptie.server.common.dto.Response;
+import com.soptie.server.routine.service.DailyRoutineService;
+
+import lombok.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/routines/daily")
+public class DailyRoutineController {
+
+	private final DailyRoutineService dailyRoutineService;
+
+	@GetMapping("/themes")
+	public ResponseEntity<Response> getThemes() {
+		val response = dailyRoutineService.getThemes();
+		return ResponseEntity.ok(success(SUCCESS_GET_THEMES.getMessage(), response));
+	}
+}

--- a/src/main/java/com/soptie/server/routine/dto/DailyThemesResponse.java
+++ b/src/main/java/com/soptie/server/routine/dto/DailyThemesResponse.java
@@ -1,0 +1,33 @@
+package com.soptie.server.routine.dto;
+
+import java.util.List;
+
+import com.soptie.server.routine.entity.daily.DailyTheme;
+
+import lombok.Builder;
+
+public record DailyThemesResponse(
+	List<DailyThemeResponse> themes
+) {
+
+	public static DailyThemesResponse of(List<DailyTheme> themes) {
+		return new DailyThemesResponse(themes.stream().map(DailyThemeResponse::of).toList());
+	}
+
+	@Builder
+	private record DailyThemeResponse(
+		Long themeId,
+		String name,
+		String iconImageUrl,
+		String backgroundImageUrl
+	) {
+		private static DailyThemeResponse of(DailyTheme theme) {
+			return DailyThemeResponse.builder()
+				.themeId(theme.getId())
+				.name(theme.getName())
+				.iconImageUrl(theme.getImageInfo().getIconImageUrl())
+				.backgroundImageUrl(theme.getImageInfo().getBackgroundImageUrl())
+				.build();
+		}
+	}
+}

--- a/src/main/java/com/soptie/server/routine/entity/daily/DailyRoutine.java
+++ b/src/main/java/com/soptie/server/routine/entity/daily/DailyRoutine.java
@@ -25,9 +25,6 @@ public class DailyRoutine {
 	@Column(nullable = false)
 	private String content;
 
-	@Embedded
-	private RoutineImage imageInfo;
-
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "theme_id")
 	private DailyTheme theme;

--- a/src/main/java/com/soptie/server/routine/entity/daily/DailyTheme.java
+++ b/src/main/java/com/soptie/server/routine/entity/daily/DailyTheme.java
@@ -1,14 +1,17 @@
 package com.soptie.server.routine.entity.daily;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor
+@Getter
 public class DailyTheme {
 
 	@Id
@@ -19,5 +22,6 @@ public class DailyTheme {
 	@Column(nullable = false)
 	private String name;
 
-	private String imageUrl;
+	@Embedded
+	private RoutineImage imageInfo;
 }

--- a/src/main/java/com/soptie/server/routine/entity/daily/RoutineImage.java
+++ b/src/main/java/com/soptie/server/routine/entity/daily/RoutineImage.java
@@ -1,12 +1,13 @@
 package com.soptie.server.routine.entity.daily;
 
 import jakarta.persistence.Embeddable;
+import lombok.Getter;
 
 @Embeddable
+@Getter
 public class RoutineImage {
 
-	private String coloredIconImageUrl;
-	private String uncoloredIconImageUrl;
+	private String iconImageUrl;
 
 	private String backgroundImageUrl;
 }

--- a/src/main/java/com/soptie/server/routine/message/ResponseMessage.java
+++ b/src/main/java/com/soptie/server/routine/message/ResponseMessage.java
@@ -1,0 +1,13 @@
+package com.soptie.server.routine.message;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ResponseMessage {
+	SUCCESS_GET_THEMES("테마 조회 성공"),
+	;
+
+	private final String message;
+}

--- a/src/main/java/com/soptie/server/routine/repository/daily/theme/DailyThemeCustomRepository.java
+++ b/src/main/java/com/soptie/server/routine/repository/daily/theme/DailyThemeCustomRepository.java
@@ -1,0 +1,9 @@
+package com.soptie.server.routine.repository.daily.theme;
+
+import java.util.List;
+
+import com.soptie.server.routine.entity.daily.DailyTheme;
+
+public interface DailyThemeCustomRepository {
+	List<DailyTheme> findAllOrderByNameAsc();
+}

--- a/src/main/java/com/soptie/server/routine/repository/daily/theme/DailyThemeRepository.java
+++ b/src/main/java/com/soptie/server/routine/repository/daily/theme/DailyThemeRepository.java
@@ -1,0 +1,8 @@
+package com.soptie.server.routine.repository.daily.theme;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.soptie.server.routine.entity.daily.DailyTheme;
+
+public interface DailyThemeRepository extends JpaRepository<DailyTheme, Long>, DailyThemeCustomRepository {
+}

--- a/src/main/java/com/soptie/server/routine/repository/daily/theme/DailyThemeRepositoryImpl.java
+++ b/src/main/java/com/soptie/server/routine/repository/daily/theme/DailyThemeRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.soptie.server.routine.repository.daily.theme;
+
+import static com.soptie.server.routine.entity.daily.QDailyTheme.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.soptie.server.routine.entity.daily.DailyTheme;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class DailyThemeRepositoryImpl implements DailyThemeCustomRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<DailyTheme> findAllOrderByNameAsc() {
+		return queryFactory
+			.selectFrom(dailyTheme)
+			.orderBy(dailyTheme.name.asc())
+			.fetch();
+	}
+}

--- a/src/main/java/com/soptie/server/routine/service/DailyRoutineService.java
+++ b/src/main/java/com/soptie/server/routine/service/DailyRoutineService.java
@@ -1,0 +1,20 @@
+package com.soptie.server.routine.service;
+
+import org.springframework.stereotype.Service;
+
+import com.soptie.server.routine.dto.DailyThemesResponse;
+import com.soptie.server.routine.repository.daily.theme.DailyThemeRepository;
+
+import lombok.*;
+
+@Service
+@RequiredArgsConstructor
+public class DailyRoutineService {
+
+	private final DailyThemeRepository dailyThemeRepository;
+
+	public DailyThemesResponse getThemes() {
+		val themes = dailyThemeRepository.findAllOrderByNameAsc();
+		return DailyThemesResponse.of(themes);
+	}
+}


### PR DESCRIPTION
## ✨ Related Issue
- close #15 
  <br/>

## 📝 기능 구현 명세
<img width="975" alt="image" src="https://github.com/Team-Sopetit/Sopetit-server/assets/55437339/bed5b953-3aef-4f87-a9da-1d0f39275198">


## 🐥 추가적인 언급 사항
- 예시 API가 필요하다고 하여, 우선 테스트 진행 전 PR 업로드 했습니다.
- DB 세팅 후 추가적인 테스트, 코드 리팩토링, 의논 반영 등 작업 진행하겠습니다.
- 유연한 쿼리 환경을 위해 QueryDSL을 추가했습니다.
- 데일리 루틴의 테마에 따라 이미지 정보가 결정되어 테마 엔티티로 이미지 정보를 이동했습니다.
- 아이콘이 루틴 달성 여부에 관계없이 유색 이미지로 통일되는 것으로 전달받아 무색 이미지는 삭제했습니다.
- 공통 ResponseDTO 클래스를 추가했습니다. 패키지 이름을 통해 클래스 역할이 정의된다고 생각하여 클래스명은 Response로 우선 정의했습니다.
- 자유롭게 의견이나 궁금한 점 있으시면 리뷰로 부탁드려요 :)