### PR TITLE
[FEAT] 테마 리스트 별 루틴 리스트 조회

### DIFF
--- a/src/main/java/com/soptie/server/routine/controller/DailyRoutineController.java
+++ b/src/main/java/com/soptie/server/routine/controller/DailyRoutineController.java
@@ -6,10 +6,11 @@ import static com.soptie.server.routine.message.ResponseMessage.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.soptie.server.common.dto.Response;
-import com.soptie.server.routine.service.DailyRoutineService;
+import com.soptie.server.routine.service.DailyRoutineServiceImpl;
 
 import lombok.*;
 
@@ -18,11 +19,17 @@ import lombok.*;
 @RequestMapping("/api/v1/routines/daily")
 public class DailyRoutineController {
 
-	private final DailyRoutineService dailyRoutineService;
+	private final DailyRoutineServiceImpl dailyRoutineService;
 
 	@GetMapping("/themes")
 	public ResponseEntity<Response> getThemes() {
 		val response = dailyRoutineService.getThemes();
-		return ResponseEntity.ok(success(SUCCESS_GET_THEMES.getMessage(), response));
+		return ResponseEntity.ok(success(SUCCESS_GET_THEME.getMessage(), response));
+	}
+
+	@GetMapping
+	public ResponseEntity<Response> getRoutines(@RequestParam String themes) {
+		val response = dailyRoutineService.getRoutinesByThemes(themes);
+		return ResponseEntity.ok(success(SUCCESS_GET_ROUTINE.getMessage(), response));
 	}
 }

--- a/src/main/java/com/soptie/server/routine/controller/DailyRoutineController.java
+++ b/src/main/java/com/soptie/server/routine/controller/DailyRoutineController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.soptie.server.common.dto.Response;
-import com.soptie.server.routine.service.DailyRoutineServiceImpl;
+import com.soptie.server.routine.service.DailyRoutineService;
 
 import lombok.*;
 
@@ -19,7 +19,7 @@ import lombok.*;
 @RequestMapping("/api/v1/routines/daily")
 public class DailyRoutineController {
 
-	private final DailyRoutineServiceImpl dailyRoutineService;
+	private final DailyRoutineService dailyRoutineService;
 
 	@GetMapping("/themes")
 	public ResponseEntity<Response> getThemes() {

--- a/src/main/java/com/soptie/server/routine/dto/DailyRoutinesResponse.java
+++ b/src/main/java/com/soptie/server/routine/dto/DailyRoutinesResponse.java
@@ -1,0 +1,30 @@
+package com.soptie.server.routine.dto;
+
+import java.util.List;
+
+import com.soptie.server.routine.entity.daily.DailyRoutine;
+
+import lombok.Builder;
+
+public record DailyRoutinesResponse(
+	List<DailyRoutineResponse> routines
+) {
+
+	public static DailyRoutinesResponse of(List<DailyRoutine> routines) {
+		return new DailyRoutinesResponse(routines.stream().map(DailyRoutineResponse::of).toList());
+	}
+
+	@Builder
+	private record DailyRoutineResponse(
+		Long routineId,
+		String content
+	) {
+
+		private static DailyRoutineResponse of(DailyRoutine routine) {
+			return DailyRoutineResponse.builder()
+				.routineId(routine.getId())
+				.content(routine.getContent())
+				.build();
+		}
+	}
+}

--- a/src/main/java/com/soptie/server/routine/entity/daily/DailyRoutine.java
+++ b/src/main/java/com/soptie/server/routine/entity/daily/DailyRoutine.java
@@ -8,11 +8,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor
+@AllArgsConstructor
 @Getter
 public class DailyRoutine {
 

--- a/src/main/java/com/soptie/server/routine/entity/daily/DailyRoutine.java
+++ b/src/main/java/com/soptie/server/routine/entity/daily/DailyRoutine.java
@@ -1,20 +1,19 @@
 package com.soptie.server.routine.entity.daily;
 
 import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor
+@Getter
 public class DailyRoutine {
 
 	@Id

--- a/src/main/java/com/soptie/server/routine/entity/daily/DailyTheme.java
+++ b/src/main/java/com/soptie/server/routine/entity/daily/DailyTheme.java
@@ -6,11 +6,13 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor
+@AllArgsConstructor
 @Getter
 public class DailyTheme {
 

--- a/src/main/java/com/soptie/server/routine/entity/daily/RoutineImage.java
+++ b/src/main/java/com/soptie/server/routine/entity/daily/RoutineImage.java
@@ -1,9 +1,13 @@
 package com.soptie.server.routine.entity.daily;
 
 import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Embeddable
+@NoArgsConstructor
+@AllArgsConstructor
 @Getter
 public class RoutineImage {
 

--- a/src/main/java/com/soptie/server/routine/message/ResponseMessage.java
+++ b/src/main/java/com/soptie/server/routine/message/ResponseMessage.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum ResponseMessage {
-	SUCCESS_GET_THEMES("테마 조회 성공"),
+	SUCCESS_GET_THEME("데일리 루틴 테마 조회 성공"),
+	SUCCESS_GET_ROUTINE("데일리 루틴 조회 성공"),
 	;
 
 	private final String message;

--- a/src/main/java/com/soptie/server/routine/repository/daily/routine/DailyRoutineCustomRepository.java
+++ b/src/main/java/com/soptie/server/routine/repository/daily/routine/DailyRoutineCustomRepository.java
@@ -1,0 +1,9 @@
+package com.soptie.server.routine.repository.daily.routine;
+
+import java.util.List;
+
+import com.soptie.server.routine.entity.daily.DailyRoutine;
+
+public interface DailyRoutineCustomRepository {
+	List<DailyRoutine> findAllByThemes(List<Long> themeIds);
+}

--- a/src/main/java/com/soptie/server/routine/repository/daily/routine/DailyRoutineRepository.java
+++ b/src/main/java/com/soptie/server/routine/repository/daily/routine/DailyRoutineRepository.java
@@ -1,0 +1,8 @@
+package com.soptie.server.routine.repository.daily.routine;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.soptie.server.routine.entity.daily.DailyRoutine;
+
+public interface DailyRoutineRepository extends JpaRepository<DailyRoutine, Long>, DailyRoutineCustomRepository {
+}

--- a/src/main/java/com/soptie/server/routine/repository/daily/routine/DailyRoutineRepositoryImpl.java
+++ b/src/main/java/com/soptie/server/routine/repository/daily/routine/DailyRoutineRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.soptie.server.routine.repository.daily.routine;
+
+import static com.soptie.server.routine.entity.daily.QDailyRoutine.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.soptie.server.routine.entity.daily.DailyRoutine;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class DailyRoutineRepositoryImpl implements DailyRoutineCustomRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<DailyRoutine> findAllByThemes(List<Long> themeIds) {
+		return queryFactory
+			.selectFrom(dailyRoutine)
+			.where(dailyRoutine.theme.id.in(themeIds))
+			.fetch();
+	}
+}

--- a/src/main/java/com/soptie/server/routine/service/DailyRoutineService.java
+++ b/src/main/java/com/soptie/server/routine/service/DailyRoutineService.java
@@ -1,20 +1,10 @@
 package com.soptie.server.routine.service;
 
-import org.springframework.stereotype.Service;
-
+import com.soptie.server.routine.dto.DailyRoutinesResponse;
 import com.soptie.server.routine.dto.DailyThemesResponse;
-import com.soptie.server.routine.repository.daily.theme.DailyThemeRepository;
 
-import lombok.*;
+public interface DailyRoutineService {
 
-@Service
-@RequiredArgsConstructor
-public class DailyRoutineService {
-
-	private final DailyThemeRepository dailyThemeRepository;
-
-	public DailyThemesResponse getThemes() {
-		val themes = dailyThemeRepository.findAllOrderByNameAsc();
-		return DailyThemesResponse.of(themes);
-	}
+	DailyThemesResponse getThemes();
+	DailyRoutinesResponse getRoutinesByThemes(String themes);
 }

--- a/src/main/java/com/soptie/server/routine/service/DailyRoutineServiceImpl.java
+++ b/src/main/java/com/soptie/server/routine/service/DailyRoutineServiceImpl.java
@@ -1,0 +1,43 @@
+package com.soptie.server.routine.service;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.soptie.server.routine.dto.DailyRoutinesResponse;
+import com.soptie.server.routine.dto.DailyThemesResponse;
+import com.soptie.server.routine.repository.daily.routine.DailyRoutineRepository;
+import com.soptie.server.routine.repository.daily.theme.DailyThemeRepository;
+
+import lombok.*;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class DailyRoutineServiceImpl implements DailyRoutineService {
+
+	private final DailyThemeRepository dailyThemeRepository;
+	private final DailyRoutineRepository dailyRoutineRepository;
+
+	public DailyThemesResponse getThemes() {
+		val themes = dailyThemeRepository.findAllOrderByNameAsc();
+		return DailyThemesResponse.of(themes);
+	}
+
+	public DailyRoutinesResponse getRoutinesByThemes(String themes) {
+		val themeIds = getThemeIds(themes);
+		val routines = dailyRoutineRepository.findAllByThemes(themeIds);
+		return DailyRoutinesResponse.of(routines);
+	}
+
+	private List<Long> getThemeIds(String themes) {
+		val themeList = convertStringToList(themes);
+		return themeList.stream().map(Long::valueOf).toList();
+	}
+
+	private List<String> convertStringToList(String themes) {
+		return Arrays.stream(themes.split(",")).toList();
+	}
+}

--- a/src/main/java/com/soptie/server/routine/service/DailyRoutineServiceImpl.java
+++ b/src/main/java/com/soptie/server/routine/service/DailyRoutineServiceImpl.java
@@ -21,11 +21,13 @@ public class DailyRoutineServiceImpl implements DailyRoutineService {
 	private final DailyThemeRepository dailyThemeRepository;
 	private final DailyRoutineRepository dailyRoutineRepository;
 
+	@Override
 	public DailyThemesResponse getThemes() {
 		val themes = dailyThemeRepository.findAllOrderByNameAsc();
 		return DailyThemesResponse.of(themes);
 	}
 
+	@Override
 	public DailyRoutinesResponse getRoutinesByThemes(String themes) {
 		val themeIds = getThemeIds(themes);
 		val routines = dailyRoutineRepository.findAllByThemes(themeIds);

--- a/src/main/resources/static/docs/open-api-3.0.1.json
+++ b/src/main/resources/static/docs/open-api-3.0.1.json
@@ -34,10 +34,149 @@
           }
         }
       }
+    },
+    "/api/v1/routines/daily" : {
+      "get" : {
+        "tags" : [ "DAILY ROUTINE" ],
+        "summary" : "테마 리스트 별 데일리 루틴 리스트 조회",
+        "description" : "테마 리스트 별 데일리 루틴 리스트 조회",
+        "operationId" : "get-routines-docs",
+        "parameters" : [ {
+          "name" : "themes",
+          "in" : "query",
+          "description" : "조회할 테마 id 정보",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json;charset=UTF-8" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/api-v1-routines-daily-54531209"
+                },
+                "examples" : {
+                  "get-routines-docs" : {
+                    "value" : "{\n  \"success\" : true,\n  \"message\" : \"루틴 조회 성공\",\n  \"data\" : {\n    \"routines\" : [ {\n      \"routineId\" : 0,\n      \"content\" : \"content0\"\n    }, {\n      \"routineId\" : 1,\n      \"content\" : \"content1\"\n    }, {\n      \"routineId\" : 2,\n      \"content\" : \"content2\"\n    }, {\n      \"routineId\" : 3,\n      \"content\" : \"content3\"\n    }, {\n      \"routineId\" : 4,\n      \"content\" : \"content4\"\n    } ]\n  }\n}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/routines/daily/themes" : {
+      "get" : {
+        "tags" : [ "DAILY ROUTINE" ],
+        "summary" : "데일리 루틴 테마 리스트 조회",
+        "description" : "데일리 루틴 테마 리스트 조회",
+        "operationId" : "get-themes-docs",
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json;charset=UTF-8" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/api-v1-routines-daily-themes1975236624"
+                },
+                "examples" : {
+                  "get-themes-docs" : {
+                    "value" : "{\n  \"success\" : true,\n  \"message\" : \"테마 조회 성공\",\n  \"data\" : {\n    \"themes\" : [ {\n      \"themeId\" : 0,\n      \"name\" : \"Daily routine Theme0\",\n      \"iconImageUrl\" : \"icon_image_url0\",\n      \"backgroundImageUrl\" : \"background_image_url0\"\n    }, {\n      \"themeId\" : 1,\n      \"name\" : \"Daily routine Theme1\",\n      \"iconImageUrl\" : \"icon_image_url1\",\n      \"backgroundImageUrl\" : \"background_image_url1\"\n    }, {\n      \"themeId\" : 2,\n      \"name\" : \"Daily routine Theme2\",\n      \"iconImageUrl\" : \"icon_image_url2\",\n      \"backgroundImageUrl\" : \"background_image_url2\"\n    }, {\n      \"themeId\" : 3,\n      \"name\" : \"Daily routine Theme3\",\n      \"iconImageUrl\" : \"icon_image_url3\",\n      \"backgroundImageUrl\" : \"background_image_url3\"\n    }, {\n      \"themeId\" : 4,\n      \"name\" : \"Daily routine Theme4\",\n      \"iconImageUrl\" : \"icon_image_url4\",\n      \"backgroundImageUrl\" : \"background_image_url4\"\n    } ]\n  }\n}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components" : {
     "schemas" : {
+      "api-v1-routines-daily-54531209" : {
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "type" : "object",
+            "properties" : {
+              "routines" : {
+                "type" : "array",
+                "description" : "루틴 정보 리스트",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "routineId" : {
+                      "type" : "number",
+                      "description" : "루틴 id"
+                    },
+                    "content" : {
+                      "type" : "string",
+                      "description" : "테마 내용"
+                    }
+                  }
+                }
+              }
+            },
+            "description" : "응답 데이터"
+          },
+          "success" : {
+            "type" : "boolean",
+            "description" : "응답 성공 여부"
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "응답 메시지"
+          }
+        }
+      },
+      "api-v1-routines-daily-themes1975236624" : {
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "type" : "object",
+            "properties" : {
+              "themes" : {
+                "type" : "array",
+                "description" : "테마 정보 리스트",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "iconImageUrl" : {
+                      "type" : "string",
+                      "description" : "아이콘 이미지 url"
+                    },
+                    "name" : {
+                      "type" : "string",
+                      "description" : "테마 이름"
+                    },
+                    "themeId" : {
+                      "type" : "number",
+                      "description" : "테마 id"
+                    },
+                    "backgroundImageUrl" : {
+                      "type" : "string",
+                      "description" : "배경 이미지 url"
+                    }
+                  }
+                }
+              }
+            },
+            "description" : "응답 데이터"
+          },
+          "success" : {
+            "type" : "boolean",
+            "description" : "응답 성공 여부"
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "응답 메시지"
+          }
+        }
+      },
       "api-v1-test486549215" : {
         "type" : "object"
       }

--- a/src/test/java/com/soptie/server/routine/controller/DailyRoutineControllerTest.java
+++ b/src/test/java/com/soptie/server/routine/controller/DailyRoutineControllerTest.java
@@ -1,0 +1,74 @@
+package com.soptie.server.routine.controller;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.soptie.server.base.BaseControllerTest;
+import com.soptie.server.common.dto.Response;
+import com.soptie.server.routine.dto.DailyThemesResponse;
+
+@WebMvcTest(DailyRoutineController.class)
+class DailyRoutineControllerTest extends BaseControllerTest {
+
+	@MockBean
+	DailyRoutineController controller;
+
+	private final String DEFAULT_URL = "/api/v1/routines/daily";
+	private final String TAG = "DAILY ROUTINE";
+
+	@Test
+	@DisplayName("데일리 루틴 테마 리스트 조회 성공")
+	void success_getDailyThemes() throws Exception {
+		// given
+		DailyThemesResponse themes = DailyRoutineFixture.createDailyThemesResponseDTO();
+		ResponseEntity<Response> response = ResponseEntity.ok(Response.success("테마 전체 조회", themes));
+
+		// when
+		when(controller.getThemes()).thenReturn(response);
+
+		// then
+		mockMvc
+			.perform(
+				RestDocumentationRequestBuilders.get(DEFAULT_URL + "/themes")
+					.contentType(MediaType.APPLICATION_JSON)
+					.accept(MediaType.APPLICATION_JSON))
+			.andDo(
+				MockMvcRestDocumentation.document(
+					"get-themes-docs",
+					preprocessRequest(prettyPrint()),
+					preprocessResponse(prettyPrint()),
+					resource(
+						ResourceSnippetParameters.builder()
+							.tag(TAG)
+							.description("데일리 루틴 테마 리스트 조회")
+							.requestFields()
+							.responseFields(
+								fieldWithPath("success").type(BOOLEAN).description("응답 성공 여부"),
+								fieldWithPath("message").type(STRING).description("응답 메시지"),
+								fieldWithPath("data").type(OBJECT).description("응답 데이터"),
+								fieldWithPath("data.themes").type(ARRAY).description("테마 정보 리스트"),
+								fieldWithPath("data.themes[].themeId").type(NUMBER).description("테마 id"),
+								fieldWithPath("data.themes[].name").type(STRING).description("테마 이름"),
+								fieldWithPath("data.themes[].iconImageUrl").type(STRING).description("아이콘 이미지 url"),
+								fieldWithPath("data.themes[].backgroundImageUrl").type(STRING).description("배경 이미지 url")
+							)
+							.build())))
+			.andExpect(status().isOk());
+	}
+
+}

--- a/src/test/java/com/soptie/server/routine/controller/DailyRoutineControllerTest.java
+++ b/src/test/java/com/soptie/server/routine/controller/DailyRoutineControllerTest.java
@@ -21,6 +21,7 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.soptie.server.base.BaseControllerTest;
 import com.soptie.server.common.dto.Response;
 import com.soptie.server.routine.dto.DailyThemesResponse;
+import com.soptie.server.routine.fixture.DailyRoutineFixture;
 
 @WebMvcTest(DailyRoutineController.class)
 class DailyRoutineControllerTest extends BaseControllerTest {

--- a/src/test/java/com/soptie/server/routine/fixture/DailyRoutineFixture.java
+++ b/src/test/java/com/soptie/server/routine/fixture/DailyRoutineFixture.java
@@ -3,7 +3,9 @@ package com.soptie.server.routine.fixture;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.soptie.server.routine.dto.DailyRoutinesResponse;
 import com.soptie.server.routine.dto.DailyThemesResponse;
+import com.soptie.server.routine.entity.daily.DailyRoutine;
 import com.soptie.server.routine.entity.daily.DailyTheme;
 import com.soptie.server.routine.entity.daily.RoutineImage;
 
@@ -34,5 +36,23 @@ public class DailyRoutineFixture {
 	private static DailyTheme createDailyTheme(Long id, String name, String iconImageUrl, String backgroundImageUrl) {
 		RoutineImage routineImage = new RoutineImage(iconImageUrl, backgroundImageUrl);
 		return new DailyTheme(id, name, routineImage);
+	}
+
+	public static DailyRoutinesResponse createDailyRoutinesResponseDTO() {
+		List<DailyRoutine> routines = getDailyRoutines();
+		return DailyRoutinesResponse.of(routines);
+	}
+
+	private static List<DailyRoutine> getDailyRoutines() {
+		List<DailyRoutine> routines = new ArrayList<>();
+		DailyTheme theme = createDailyTheme(1L, "테스트 테마", "test-icon", "test-background");
+		for (int i = 0; i < 5; i++) {
+			routines.add(createDailyRoutine((long)i, "content" + i, theme));
+		}
+		return routines;
+	}
+
+	private static DailyRoutine createDailyRoutine(Long id, String content, DailyTheme theme) {
+		return new DailyRoutine(id, content, theme);
 	}
 }

--- a/src/test/java/com/soptie/server/routine/fixture/DailyRoutineFixture.java
+++ b/src/test/java/com/soptie/server/routine/fixture/DailyRoutineFixture.java
@@ -1,0 +1,38 @@
+package com.soptie.server.routine.fixture;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.soptie.server.routine.dto.DailyThemesResponse;
+import com.soptie.server.routine.entity.daily.DailyTheme;
+import com.soptie.server.routine.entity.daily.RoutineImage;
+
+public class DailyRoutineFixture {
+
+	private static final String NAME = "Daily routine Theme";
+
+	private static final String ICON_IMAGE_URL = "icon_image_url";
+	private static final String BACKGROUND_IMAGE_URL = "background_image_url";
+
+	public static DailyThemesResponse createDailyThemesResponseDTO() {
+		List<DailyTheme> themes = getDailyThemes();
+		return DailyThemesResponse.of(themes);
+	}
+
+	private static List<DailyTheme> getDailyThemes() {
+		List<DailyTheme> themes = new ArrayList<>();
+		for (int i = 0; i < 5; i++) {
+			themes.add(createDailyTheme(
+				(long)i,
+				NAME + i,
+				ICON_IMAGE_URL + i,
+				BACKGROUND_IMAGE_URL + i));
+		}
+		return themes;
+	}
+
+	private static DailyTheme createDailyTheme(Long id, String name, String iconImageUrl, String backgroundImageUrl) {
+		RoutineImage routineImage = new RoutineImage(iconImageUrl, backgroundImageUrl);
+		return new DailyTheme(id, name, routineImage);
+	}
+}


### PR DESCRIPTION
## ✨ Related Issue
- close #20 
  <br/>

## 📝 기능 구현 명세
<img width="972" alt="image" src="https://github.com/Team-Sopetit/Sopetit-server/assets/55437339/f8ebf8de-671c-429f-ab78-5fe0511ed0d8">

## 🐥 추가적인 언급 사항
- Service Layer를 인터페이스로 분리함으로써 Controller과의 결합도와 의존성을 낮췄습니다.
- 이전 PR에서 누락된 테스트 코드를 추가했습니다.