### PR TITLE
[FEAT] 테마 별 데일리 루틴 리스트 조회

### DIFF
--- a/src/main/java/com/soptie/server/common/handler/ErrorHandler.java
+++ b/src/main/java/com/soptie/server/common/handler/ErrorHandler.java
@@ -10,12 +10,15 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import com.soptie.server.common.dto.Response;
 
 import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestControllerAdvice
 public class ErrorHandler {
 
 	@ExceptionHandler(EntityNotFoundException.class)
 	public ResponseEntity<Response> entityNotFoundException(EntityNotFoundException exception) {
+		log.error(exception.getMessage());
 		return ResponseEntity.status(NOT_FOUND).body(fail(exception.getMessage()));
 	}
 }

--- a/src/main/java/com/soptie/server/common/handler/ErrorHandler.java
+++ b/src/main/java/com/soptie/server/common/handler/ErrorHandler.java
@@ -1,0 +1,21 @@
+package com.soptie.server.common.handler;
+
+import static com.soptie.server.common.dto.Response.*;
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.soptie.server.common.dto.Response;
+
+import jakarta.persistence.EntityNotFoundException;
+
+@RestControllerAdvice
+public class ErrorHandler {
+
+	@ExceptionHandler(EntityNotFoundException.class)
+	public ResponseEntity<Response> entityNotFoundException(EntityNotFoundException exception) {
+		return ResponseEntity.status(NOT_FOUND).body(fail(exception.getMessage()));
+	}
+}

--- a/src/main/java/com/soptie/server/routine/controller/DailyRoutineController.java
+++ b/src/main/java/com/soptie/server/routine/controller/DailyRoutineController.java
@@ -5,6 +5,7 @@ import static com.soptie.server.routine.message.ResponseMessage.*;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,8 +29,14 @@ public class DailyRoutineController {
 	}
 
 	@GetMapping
-	public ResponseEntity<Response> getRoutines(@RequestParam String themes) {
+	public ResponseEntity<Response> getRoutinesByThemes(@RequestParam String themes) {
 		val response = dailyRoutineService.getRoutinesByThemes(themes);
+		return ResponseEntity.ok(success(SUCCESS_GET_ROUTINE.getMessage(), response));
+	}
+
+	@GetMapping("/{themeId}")
+	public ResponseEntity<Response> getRoutinesByTheme(@PathVariable Long themeId) {
+		val response = dailyRoutineService.getRoutinesByTheme(themeId);
 		return ResponseEntity.ok(success(SUCCESS_GET_ROUTINE.getMessage(), response));
 	}
 }

--- a/src/main/java/com/soptie/server/routine/message/ErrorMessage.java
+++ b/src/main/java/com/soptie/server/routine/message/ErrorMessage.java
@@ -1,0 +1,13 @@
+package com.soptie.server.routine.message;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ErrorMessage {
+	INVALID_THEME("유효하지 않은 테마입니다."),
+	;
+
+	private final String message;
+}

--- a/src/main/java/com/soptie/server/routine/repository/daily/routine/DailyRoutineRepository.java
+++ b/src/main/java/com/soptie/server/routine/repository/daily/routine/DailyRoutineRepository.java
@@ -1,8 +1,12 @@
 package com.soptie.server.routine.repository.daily.routine;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.soptie.server.routine.entity.daily.DailyRoutine;
+import com.soptie.server.routine.entity.daily.DailyTheme;
 
 public interface DailyRoutineRepository extends JpaRepository<DailyRoutine, Long>, DailyRoutineCustomRepository {
+	List<DailyRoutine> findAllByThemeOrderByContentAsc(DailyTheme theme);
 }

--- a/src/main/java/com/soptie/server/routine/repository/daily/routine/DailyRoutineRepositoryImpl.java
+++ b/src/main/java/com/soptie/server/routine/repository/daily/routine/DailyRoutineRepositoryImpl.java
@@ -22,6 +22,7 @@ public class DailyRoutineRepositoryImpl implements DailyRoutineCustomRepository 
 		return queryFactory
 			.selectFrom(dailyRoutine)
 			.where(dailyRoutine.theme.id.in(themeIds))
+			.orderBy(dailyRoutine.content.asc())
 			.fetch();
 	}
 }

--- a/src/main/java/com/soptie/server/routine/service/DailyRoutineService.java
+++ b/src/main/java/com/soptie/server/routine/service/DailyRoutineService.java
@@ -7,4 +7,5 @@ public interface DailyRoutineService {
 
 	DailyThemesResponse getThemes();
 	DailyRoutinesResponse getRoutinesByThemes(String themes);
+	DailyRoutinesResponse getRoutinesByTheme(Long themeId);
 }

--- a/src/main/java/com/soptie/server/routine/service/DailyRoutineServiceImpl.java
+++ b/src/main/java/com/soptie/server/routine/service/DailyRoutineServiceImpl.java
@@ -1,5 +1,7 @@
 package com.soptie.server.routine.service;
 
+import static com.soptie.server.routine.message.ErrorMessage.*;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -8,9 +10,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.soptie.server.routine.dto.DailyRoutinesResponse;
 import com.soptie.server.routine.dto.DailyThemesResponse;
+import com.soptie.server.routine.entity.daily.DailyTheme;
 import com.soptie.server.routine.repository.daily.routine.DailyRoutineRepository;
 import com.soptie.server.routine.repository.daily.theme.DailyThemeRepository;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.*;
 
 @Service
@@ -21,11 +25,13 @@ public class DailyRoutineServiceImpl implements DailyRoutineService {
 	private final DailyThemeRepository dailyThemeRepository;
 	private final DailyRoutineRepository dailyRoutineRepository;
 
+	@Override
 	public DailyThemesResponse getThemes() {
 		val themes = dailyThemeRepository.findAllOrderByNameAsc();
 		return DailyThemesResponse.of(themes);
 	}
 
+	@Override
 	public DailyRoutinesResponse getRoutinesByThemes(String themes) {
 		val themeIds = getThemeIds(themes);
 		val routines = dailyRoutineRepository.findAllByThemes(themeIds);
@@ -39,5 +45,17 @@ public class DailyRoutineServiceImpl implements DailyRoutineService {
 
 	private List<String> convertStringToList(String themes) {
 		return Arrays.stream(themes.split(",")).toList();
+	}
+
+	@Override
+	public DailyRoutinesResponse getRoutinesByTheme(Long themeId) {
+		val theme = getTheme(themeId);
+		val routines = dailyRoutineRepository.findAllByThemeOrderByContentAsc(theme);
+		return DailyRoutinesResponse.of(routines);
+	}
+
+	private DailyTheme getTheme(Long id) {
+		return dailyThemeRepository.findById(id)
+			.orElseThrow(() -> new EntityNotFoundException(INVALID_THEME.getMessage()));
 	}
 }

--- a/src/main/resources/static/docs/open-api-3.0.1.json
+++ b/src/main/resources/static/docs/open-api-3.0.1.json
@@ -35,40 +35,6 @@
         }
       }
     },
-    "/api/v1/routines/daily" : {
-      "get" : {
-        "tags" : [ "DAILY ROUTINE" ],
-        "summary" : "테마 리스트 별 데일리 루틴 리스트 조회",
-        "description" : "테마 리스트 별 데일리 루틴 리스트 조회",
-        "operationId" : "get-routines-docs",
-        "parameters" : [ {
-          "name" : "themes",
-          "in" : "query",
-          "description" : "조회할 테마 id 정보",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "200",
-            "content" : {
-              "application/json;charset=UTF-8" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-routines-daily-54531209"
-                },
-                "examples" : {
-                  "get-routines-docs" : {
-                    "value" : "{\n  \"success\" : true,\n  \"message\" : \"루틴 조회 성공\",\n  \"data\" : {\n    \"routines\" : [ {\n      \"routineId\" : 0,\n      \"content\" : \"content0\"\n    }, {\n      \"routineId\" : 1,\n      \"content\" : \"content1\"\n    }, {\n      \"routineId\" : 2,\n      \"content\" : \"content2\"\n    }, {\n      \"routineId\" : 3,\n      \"content\" : \"content3\"\n    }, {\n      \"routineId\" : 4,\n      \"content\" : \"content4\"\n    } ]\n  }\n}"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v1/routines/daily/themes" : {
       "get" : {
         "tags" : [ "DAILY ROUTINE" ],
@@ -93,11 +59,45 @@
           }
         }
       }
+    },
+    "/api/v1/routines/daily/{themeId}" : {
+      "get" : {
+        "tags" : [ "DAILY ROUTINE" ],
+        "summary" : "테마 별 데일리 루틴 리스트 조회",
+        "description" : "테마 별 데일리 루틴 리스트 조회",
+        "operationId" : "get-routines-docs",
+        "parameters" : [ {
+          "name" : "themeId",
+          "in" : "path",
+          "description" : "테마 id",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json;charset=UTF-8" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/api-v1-routines-daily-themeId-54531209"
+                },
+                "examples" : {
+                  "get-routines-docs" : {
+                    "value" : "{\n  \"success\" : true,\n  \"message\" : \"루틴 조회 성공\",\n  \"data\" : {\n    \"routines\" : [ {\n      \"routineId\" : 0,\n      \"content\" : \"content0\"\n    }, {\n      \"routineId\" : 1,\n      \"content\" : \"content1\"\n    }, {\n      \"routineId\" : 2,\n      \"content\" : \"content2\"\n    }, {\n      \"routineId\" : 3,\n      \"content\" : \"content3\"\n    }, {\n      \"routineId\" : 4,\n      \"content\" : \"content4\"\n    } ]\n  }\n}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components" : {
     "schemas" : {
-      "api-v1-routines-daily-54531209" : {
+      "api-v1-routines-daily-themeId-54531209" : {
         "type" : "object",
         "properties" : {
           "data" : {

--- a/src/main/resources/static/docs/open-api-3.0.1.json
+++ b/src/main/resources/static/docs/open-api-3.0.1.json
@@ -35,6 +35,40 @@
         }
       }
     },
+    "/api/v1/dolls/image/{type}" : {
+      "get" : {
+        "tags" : [ "DOLL" ],
+        "summary" : "인형 이미지 조회",
+        "description" : "인형 이미지 조회",
+        "operationId" : "get-doll-image-docs",
+        "parameters" : [ {
+          "name" : "type",
+          "in" : "path",
+          "description" : "인형 타입",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json;charset=UTF-8" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/api-v1-dolls-image-type-1785135499"
+                },
+                "examples" : {
+                  "get-doll-image-docs" : {
+                    "value" : "{\n  \"success\" : true,\n  \"message\" : \"인형 이미지 조회 성공\",\n  \"data\" : {\n    \"faceImageUrl\" : \"face-image-url\"\n  }\n}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/routines/daily/themes" : {
       "get" : {
         "tags" : [ "DAILY ROUTINE" ],
@@ -163,6 +197,29 @@
                     }
                   }
                 }
+              }
+            },
+            "description" : "응답 데이터"
+          },
+          "success" : {
+            "type" : "boolean",
+            "description" : "응답 성공 여부"
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "응답 메시지"
+          }
+        }
+      },
+      "api-v1-dolls-image-type-1785135499" : {
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "type" : "object",
+            "properties" : {
+              "faceImageUrl" : {
+                "type" : "string",
+                "description" : "인형 얼굴 이미지 url"
               }
             },
             "description" : "응답 데이터"

--- a/src/test/java/com/soptie/server/routine/controller/DailyRoutineControllerTest.java
+++ b/src/test/java/com/soptie/server/routine/controller/DailyRoutineControllerTest.java
@@ -87,7 +87,7 @@ class DailyRoutineControllerTest extends BaseControllerTest {
 		queries.add("themes", themes);
 
 		// when
-		when(controller.getRoutines(themes)).thenReturn(response);
+		when(controller.getRoutinesByThemes(themes)).thenReturn(response);
 
 		// then
 		mockMvc
@@ -107,6 +107,47 @@ class DailyRoutineControllerTest extends BaseControllerTest {
 							.description("테마 리스트 별 데일리 루틴 리스트 조회")
 							.queryParameters(
 								parameterWithName("themes").description("조회할 테마 id 정보")
+							)
+							.requestFields()
+							.responseFields(
+								fieldWithPath("success").type(BOOLEAN).description("응답 성공 여부"),
+								fieldWithPath("message").type(STRING).description("응답 메시지"),
+								fieldWithPath("data").type(OBJECT).description("응답 데이터"),
+								fieldWithPath("data.routines").type(ARRAY).description("루틴 정보 리스트"),
+								fieldWithPath("data.routines[].routineId").type(NUMBER).description("루틴 id"),
+								fieldWithPath("data.routines[].content").type(STRING).description("테마 내용")
+							)
+							.build())))
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	@DisplayName("테마 별 데일리 루틴 리스트 조회 성공")
+	void success_getDailyRoutinesByTheme() throws Exception {
+		// given
+		DailyRoutinesResponse routines = DailyRoutineFixture.createDailyRoutinesResponseDTO();
+		ResponseEntity<Response> response = ResponseEntity.ok(Response.success("루틴 조회 성공", routines));
+
+		// when
+		when(controller.getRoutinesByTheme(anyLong())).thenReturn(response);
+
+		// then
+		mockMvc
+			.perform(
+				RestDocumentationRequestBuilders.get(DEFAULT_URL + "/{themeId}", 1L)
+					.contentType(MediaType.APPLICATION_JSON)
+					.accept(MediaType.APPLICATION_JSON))
+			.andDo(
+				MockMvcRestDocumentation.document(
+					"get-routines-docs",
+					preprocessRequest(prettyPrint()),
+					preprocessResponse(prettyPrint()),
+					resource(
+						ResourceSnippetParameters.builder()
+							.tag(TAG)
+							.description("테마 별 데일리 루틴 리스트 조회")
+							.pathParameters(
+								parameterWithName("themeId").description("테마 id")
 							)
 							.requestFields()
 							.responseFields(


### PR DESCRIPTION
## ✨ Related Issue
- close #22 
  <br/>

## 📝 기능 구현 명세
<img width="956" alt="image" src="https://github.com/Team-Sopetit/Sopetit-server/assets/55437339/e2ab4a69-d429-4031-8782-9e5372ea7014">


## 🐥 추가적인 언급 사항
- 이전 PR(테마 리스트 별 데일리 루틴 리스트 조회)이 포함되어 있어요. 이전 PR 병합 후 리뷰 부탁드려요 :)