### PR TITLE
[FIX] 정렬 기준 KR로 변경

### DIFF
--- a/src/main/java/com/soptie/server/memberRoutine/repository/MemberDailyRoutineRepositoryImpl.java
+++ b/src/main/java/com/soptie/server/memberRoutine/repository/MemberDailyRoutineRepositoryImpl.java
@@ -8,11 +8,13 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.soptie.server.member.entity.Member;
 import com.soptie.server.memberRoutine.entity.daily.MemberDailyRoutine;
 
 import lombok.RequiredArgsConstructor;
+import lombok.val;
 
 @Repository
 @RequiredArgsConstructor
@@ -22,14 +24,15 @@ public class MemberDailyRoutineRepositoryImpl implements MemberDailyRoutineCusto
 
 	@Override
 	public List<MemberDailyRoutine> findAllByMember(Member member) {
+		val contentInKRExpression = Expressions.stringTemplate("SUBSTR({0}, 1, 1)", memberDailyRoutine.routine.content);
 		return queryFactory
 			.selectFrom(memberDailyRoutine)
 			.where(memberDailyRoutine.member.eq(member))
-			.leftJoin(memberDailyRoutine.routine, dailyRoutine).fetchJoin().distinct()
-			.leftJoin(dailyRoutine.theme, dailyTheme).fetchJoin().distinct()
+			.leftJoin(memberDailyRoutine.routine, dailyRoutine).fetchJoin()
+			.leftJoin(dailyRoutine.theme, dailyTheme).fetchJoin()
 			.orderBy(
 				memberDailyRoutine.achieveCount.desc(),
-				memberDailyRoutine.routine.content.asc()
+				contentInKRExpression.asc()
 			)
 			.fetch();
 	}

--- a/src/main/java/com/soptie/server/routine/controller/DailyRoutineController.java
+++ b/src/main/java/com/soptie/server/routine/controller/DailyRoutineController.java
@@ -34,7 +34,7 @@ public class DailyRoutineController {
 		return ResponseEntity.ok(success(SUCCESS_GET_ROUTINE.getMessage(), response));
 	}
 
-	@GetMapping("/{themeId}")
+	@GetMapping("/theme/{themeId}")
 	public ResponseEntity<Response> getRoutinesByTheme(@PathVariable Long themeId) {
 		val response = dailyRoutineService.getRoutinesByTheme(themeId);
 		return ResponseEntity.ok(success(SUCCESS_GET_ROUTINE.getMessage(), response));

--- a/src/main/java/com/soptie/server/routine/repository/daily/routine/DailyRoutineCustomRepository.java
+++ b/src/main/java/com/soptie/server/routine/repository/daily/routine/DailyRoutineCustomRepository.java
@@ -3,7 +3,9 @@ package com.soptie.server.routine.repository.daily.routine;
 import java.util.List;
 
 import com.soptie.server.routine.entity.daily.DailyRoutine;
+import com.soptie.server.routine.entity.daily.DailyTheme;
 
 public interface DailyRoutineCustomRepository {
 	List<DailyRoutine> findAllByThemes(List<Long> themeIds);
+	List<DailyRoutine> findAllByTheme(DailyTheme theme);
 }

--- a/src/main/java/com/soptie/server/routine/repository/daily/routine/DailyRoutineRepository.java
+++ b/src/main/java/com/soptie/server/routine/repository/daily/routine/DailyRoutineRepository.java
@@ -5,8 +5,6 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.soptie.server.routine.entity.daily.DailyRoutine;
-import com.soptie.server.routine.entity.daily.DailyTheme;
 
 public interface DailyRoutineRepository extends JpaRepository<DailyRoutine, Long>, DailyRoutineCustomRepository {
-	List<DailyRoutine> findAllByThemeOrderByContentAsc(DailyTheme theme);
 }

--- a/src/main/java/com/soptie/server/routine/repository/daily/routine/DailyRoutineRepositoryImpl.java
+++ b/src/main/java/com/soptie/server/routine/repository/daily/routine/DailyRoutineRepositoryImpl.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.soptie.server.routine.entity.daily.DailyRoutine;
+import com.soptie.server.routine.entity.daily.DailyTheme;
 
 import lombok.RequiredArgsConstructor;
 import lombok.val;
@@ -27,5 +28,15 @@ public class DailyRoutineRepositoryImpl implements DailyRoutineCustomRepository 
 			.where(dailyRoutine.theme.id.in(themeIds))
 			.orderBy(contentInKRExpression.asc())
 			.fetch();
+	}
+
+	@Override
+	public List<DailyRoutine> findAllByTheme(DailyTheme theme) {
+		val contentInKRExpression = Expressions.stringTemplate("SUBSTR({0}, 1, 1)", dailyRoutine.content);
+		return queryFactory
+				.selectFrom(dailyRoutine)
+				.where(dailyRoutine.theme.eq(theme))
+				.orderBy(contentInKRExpression.asc())
+				.fetch();
 	}
 }

--- a/src/main/java/com/soptie/server/routine/repository/daily/routine/DailyRoutineRepositoryImpl.java
+++ b/src/main/java/com/soptie/server/routine/repository/daily/routine/DailyRoutineRepositoryImpl.java
@@ -6,10 +6,12 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.soptie.server.routine.entity.daily.DailyRoutine;
 
 import lombok.RequiredArgsConstructor;
+import lombok.val;
 
 @Repository
 @RequiredArgsConstructor
@@ -19,10 +21,11 @@ public class DailyRoutineRepositoryImpl implements DailyRoutineCustomRepository 
 
 	@Override
 	public List<DailyRoutine> findAllByThemes(List<Long> themeIds) {
+		val contentInKRExpression = Expressions.stringTemplate("SUBSTR({0}, 1, 1)", dailyRoutine.content);
 		return queryFactory
 			.selectFrom(dailyRoutine)
 			.where(dailyRoutine.theme.id.in(themeIds))
-			.orderBy(dailyRoutine.content.asc())
+			.orderBy(contentInKRExpression.asc())
 			.fetch();
 	}
 }

--- a/src/main/java/com/soptie/server/routine/repository/daily/theme/DailyThemeRepositoryImpl.java
+++ b/src/main/java/com/soptie/server/routine/repository/daily/theme/DailyThemeRepositoryImpl.java
@@ -1,15 +1,18 @@
 package com.soptie.server.routine.repository.daily.theme;
 
+import static com.soptie.server.routine.entity.daily.QDailyRoutine.*;
 import static com.soptie.server.routine.entity.daily.QDailyTheme.*;
 
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.soptie.server.routine.entity.daily.DailyTheme;
 
 import lombok.RequiredArgsConstructor;
+import lombok.val;
 
 @Repository
 @RequiredArgsConstructor
@@ -19,9 +22,10 @@ public class DailyThemeRepositoryImpl implements DailyThemeCustomRepository {
 
 	@Override
 	public List<DailyTheme> findAllOrderByNameAsc() {
+		val nameInKRExpression = Expressions.stringTemplate("SUBSTR({0}, 1, 1)", dailyTheme.name);
 		return queryFactory
 			.selectFrom(dailyTheme)
-			.orderBy(dailyTheme.name.asc())
+			.orderBy(nameInKRExpression.asc())
 			.fetch();
 	}
 }

--- a/src/main/java/com/soptie/server/routine/service/DailyRoutineServiceImpl.java
+++ b/src/main/java/com/soptie/server/routine/service/DailyRoutineServiceImpl.java
@@ -50,7 +50,7 @@ public class DailyRoutineServiceImpl implements DailyRoutineService {
 	@Override
 	public DailyRoutinesResponse getRoutinesByTheme(Long themeId) {
 		val theme = getTheme(themeId);
-		val routines = dailyRoutineRepository.findAllByThemeOrderByContentAsc(theme);
+		val routines = dailyRoutineRepository.findAllByTheme(theme);
 		return DailyRoutinesResponse.of(routines);
 	}
 

--- a/src/main/resources/static/docs/open-api-3.0.1.json
+++ b/src/main/resources/static/docs/open-api-3.0.1.json
@@ -247,7 +247,7 @@
         }
       }
     },
-    "/api/v1/routines/daily/{themeId}" : {
+    "/api/v1/routines/daily/theme/{themeId}" : {
       "get" : {
         "tags" : [ "DAILY ROUTINE" ],
         "summary" : "테마 별 데일리 루틴 리스트 조회",
@@ -339,72 +339,6 @@
                 "examples" : {
                   "achieve-member-daily-routine-docs" : {
                     "value" : "{\n  \"success\" : true,\n  \"message\" : \"루틴 달성 성공\",\n  \"data\" : {\n    \"routineId\" : 1,\n    \"isAchieve\" : true,\n    \"achieveCount\" : 1\n  }\n}"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/routines/daily/member/routine/{routineId}" : {
-      "delete" : {
-        "tags" : [ "MEMBER DAILY ROUTINE" ],
-        "summary" : "회원 데일리 루틴 삭제 성공",
-        "description" : "회원 데일리 루틴 삭제 성공",
-        "operationId" : "delete-routine-docs",
-        "parameters" : [ {
-          "name" : "routineId",
-          "in" : "path",
-          "description" : "루틴 id",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "200",
-            "content" : {
-              "application/json;charset=UTF-8" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-routines-daily-member-routine-routineId594740350"
-                },
-                "examples" : {
-                  "delete-routine-docs" : {
-                    "value" : "{\r\n  \"success\" : true,\r\n  \"message\" : \"루틴 삭제 성공\",\r\n  \"data\" : null\r\n}"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch" : {
-        "tags" : [ "MEMBER DAILY ROUTINE" ],
-        "summary" : "회원 데일리 루틴 달성 성공",
-        "description" : "회원 데일리 루틴 달성 성공",
-        "operationId" : "ahieve-routine-docs",
-        "parameters" : [ {
-          "name" : "routineId",
-          "in" : "path",
-          "description" : "루틴 id",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "200",
-            "content" : {
-              "application/json;charset=UTF-8" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-routines-daily-member-routine-routineId-2021368021"
-                },
-                "examples" : {
-                  "ahieve-routine-docs" : {
-                    "value" : "{\r\n  \"success\" : true,\r\n  \"message\" : \"루틴 달성 성공\",\r\n  \"data\" : {\r\n    \"routineId\" : 1,\r\n    \"isAchieve\" : true,\r\n    \"achieveCount\" : 1\r\n  }\r\n}"
                   }
                 }
               }
@@ -568,19 +502,6 @@
           }
         }
       },
-      "api-v1-routines-daily-member-routine-routineId594740350" : {
-        "type" : "object",
-        "properties" : {
-          "success" : {
-            "type" : "boolean",
-            "description" : "응답 성공 여부"
-          },
-          "message" : {
-            "type" : "string",
-            "description" : "응답 메시지"
-          }
-        }
-      },
       "api-v1-routines-daily-member1327124516" : {
         "type" : "object",
         "properties" : {
@@ -658,37 +579,6 @@
           "socialType" : {
             "type" : "string",
             "description" : "소셜 종류"
-          }
-        }
-      },
-      "api-v1-routines-daily-member-routine-routineId-2021368021" : {
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "object",
-            "properties" : {
-              "achieveCount" : {
-                "type" : "number",
-                "description" : "달성 횟수"
-              },
-              "routineId" : {
-                "type" : "number",
-                "description" : "루틴 id"
-              },
-              "isAchieve" : {
-                "type" : "boolean",
-                "description" : "달성 여부"
-              }
-            },
-            "description" : "응답 데이터"
-          },
-          "success" : {
-            "type" : "boolean",
-            "description" : "응답 성공 여부"
-          },
-          "message" : {
-            "type" : "string",
-            "description" : "응답 메시지"
           }
         }
       },

--- a/src/test/java/com/soptie/server/routine/controller/DailyRoutineControllerTest.java
+++ b/src/test/java/com/soptie/server/routine/controller/DailyRoutineControllerTest.java
@@ -134,7 +134,7 @@ class DailyRoutineControllerTest extends BaseControllerTest {
 		// then
 		mockMvc
 			.perform(
-				RestDocumentationRequestBuilders.get(DEFAULT_URL + "/{themeId}", 1L)
+				RestDocumentationRequestBuilders.get(DEFAULT_URL + "/theme/{themeId}", 1L)
 					.contentType(MediaType.APPLICATION_JSON)
 					.accept(MediaType.APPLICATION_JSON))
 			.andDo(


### PR DESCRIPTION
## ✨ Related Issue
- close #71 
  <br/>

## 📝 기능 구현 명세
<img width="971" alt="image" src="https://github.com/Team-Sopetit/Sopetit-server/assets/55437339/74aa7827-137c-4b7b-9cca-880bcdb3f24f">
<img width="984" alt="image" src="https://github.com/Team-Sopetit/Sopetit-server/assets/55437339/7812bccd-e3eb-463a-8817-747bddd2e514">
<img width="989" alt="image" src="https://github.com/Team-Sopetit/Sopetit-server/assets/55437339/95564322-053f-49f9-bdb8-1340a8d3fd45">
<img width="973" alt="image" src="https://github.com/Team-Sopetit/Sopetit-server/assets/55437339/cd725f09-2d95-4a02-8ac0-d3c7926b797a">



## 🐥 추가적인 언급 사항
- URI의 직관적인 표현을 위해 "테마 별 데일리 루틴 리스트 조회"에서 경로를 일부 수정했습니다. (theme 추가)
- KR 기준으로 텍스트를 정렬하기 위해 Expressions 변수를 추가했습니다.
- KR 기준 정렬의 쿼리를 표현하기 위해 JPA 제공 메소드에서 QueryDSL 내 쿼리 작성으로 수정했습니다. (테마 별 루틴 조회)