### PR TITLE
[FIX] 테마 별 행복루틴 조회에서 테마 id 값을 쿼리 값으로 변경

### DIFF
--- a/src/main/java/com/soptie/server/routine/controller/HappinessRoutineController.java
+++ b/src/main/java/com/soptie/server/routine/controller/HappinessRoutineController.java
@@ -6,8 +6,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import static com.soptie.server.common.dto.Response.success;
@@ -28,8 +28,8 @@ public class HappinessRoutineController {
         return ResponseEntity.ok(success(SUCCESS_GET_HAPPINESS_THEME.getMessage(), response));
     }
 
-    @GetMapping("/theme/{themeId}")
-    public ResponseEntity<Response> getHappinessRoutinesByThemes(@PathVariable Long themeId) {
+    @GetMapping
+    public ResponseEntity<Response> getHappinessRoutinesByThemes(@RequestParam(required = false) Long themeId) {
         val response = happinessRoutineService.getHappinessRoutinesByTheme(themeId);
         return ResponseEntity.ok(success(SUCCESS_GET_HAPPINESS_ROUTINE.getMessage(), response));
     }

--- a/src/main/java/com/soptie/server/routine/repository/happiness/routine/HappinessRoutineCustomRepository.java
+++ b/src/main/java/com/soptie/server/routine/repository/happiness/routine/HappinessRoutineCustomRepository.java
@@ -6,5 +6,5 @@ import com.soptie.server.routine.entity.happiness.HappinessTheme;
 import java.util.List;
 
 public interface HappinessRoutineCustomRepository {
-    List<HappinessRoutine> findAllByTheme(HappinessTheme theme);
+    List<HappinessRoutine> findAllByThemeId(Long themeId);
 }

--- a/src/main/java/com/soptie/server/routine/repository/happiness/routine/HappinessRoutineRepositoryImpl.java
+++ b/src/main/java/com/soptie/server/routine/repository/happiness/routine/HappinessRoutineRepositoryImpl.java
@@ -1,10 +1,10 @@
 package com.soptie.server.routine.repository.happiness.routine;
 
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.soptie.server.routine.entity.happiness.HappinessRoutine;
-import com.soptie.server.routine.entity.happiness.HappinessTheme;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.springframework.stereotype.Repository;
@@ -13,6 +13,7 @@ import java.util.List;
 
 import static com.soptie.server.routine.entity.happiness.QHappinessRoutine.happinessRoutine;
 import static com.soptie.server.routine.entity.happiness.QHappinessTheme.happinessTheme;
+import static java.util.Objects.*;
 
 @Repository
 @RequiredArgsConstructor
@@ -21,13 +22,17 @@ public class HappinessRoutineRepositoryImpl implements HappinessRoutineCustomRep
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<HappinessRoutine> findAllByTheme(HappinessTheme theme) {
+    public List<HappinessRoutine> findAllByThemeId(Long themeId) {
         val titleInKRExpression = Expressions.stringTemplate("SUBSTR({0}, 1, 1)", happinessRoutine.title);
         return queryFactory
                 .selectFrom(happinessRoutine)
-                .where(happinessRoutine.theme.eq(theme))
+                .where(themeIdEq(themeId))
                 .leftJoin(happinessRoutine.theme, happinessTheme).fetchJoin()
                 .orderBy(titleInKRExpression.asc())
                 .fetch();
+    }
+
+    private BooleanExpression themeIdEq(Long themeId) {
+        return nonNull(themeId) ? happinessRoutine.theme.id.eq(themeId): null;
     }
 }

--- a/src/main/java/com/soptie/server/routine/service/HappinessRoutineServiceImpl.java
+++ b/src/main/java/com/soptie/server/routine/service/HappinessRoutineServiceImpl.java
@@ -2,16 +2,12 @@ package com.soptie.server.routine.service;
 
 import com.soptie.server.routine.dto.HappinessRoutinesResponse;
 import com.soptie.server.routine.dto.HappinessThemesResponse;
-import com.soptie.server.routine.entity.happiness.HappinessTheme;
 import com.soptie.server.routine.repository.happiness.routine.HappinessRoutineRepository;
 import com.soptie.server.routine.repository.happiness.theme.HappinessThemeRepository;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import static com.soptie.server.routine.message.ErrorMessage.INVALID_THEME;
 
 @Service
 @Transactional(readOnly = true)
@@ -31,13 +27,7 @@ public class HappinessRoutineServiceImpl implements HappinessRoutineService {
 
     @Override
     public HappinessRoutinesResponse getHappinessRoutinesByTheme(Long themeId) {
-        val theme = getTheme(themeId);
-        val routines = happinessRoutineRepository.findAllByTheme(theme);
+        val routines = happinessRoutineRepository.findAllByThemeId(themeId);
         return HappinessRoutinesResponse.of(routines);
-    }
-
-    private HappinessTheme getTheme(Long id) {
-        return happinessThemeRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(INVALID_THEME.getMessage()));
     }
 }

--- a/src/main/resources/static/docs/open-api-3.0.1.json
+++ b/src/main/resources/static/docs/open-api-3.0.1.json
@@ -60,6 +60,29 @@
       }
     },
     "/api/v1/members" : {
+      "get" : {
+        "tags" : [ "MEMBER" ],
+        "summary" : "홈 화면 불러오기",
+        "description" : "홈 화면 불러오기",
+        "operationId" : "get-member-home-screen-docs",
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json;charset=UTF-8" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/api-v1-members-980081866"
+                },
+                "examples" : {
+                  "get-member-home-screen-docs" : {
+                    "value" : "{\n  \"success\" : true,\n  \"message\" : \"홈 화면 불러오기 성공\",\n  \"data\" : {\n    \"name\" : \"softie\",\n    \"dollType\" : \"BROWN\",\n    \"frameImageUrl\" : \"frameImageUrl\",\n    \"dailyCottonCount\" : 0,\n    \"happinessCottonCount\" : 0,\n    \"conversations\" : [ \"안녕\", \"하이\", \"봉쥬르\" ]\n  }\n}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "post" : {
         "tags" : [ "MEMBER" ],
         "summary" : "프로필 생성",
@@ -123,6 +146,65 @@
                 "examples" : {
                   "test-docs" : {
                     "value" : "Success to server connect."
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/logout" : {
+      "post" : {
+        "tags" : [ "AUTH" ],
+        "summary" : "로그아웃",
+        "description" : "로그아웃",
+        "operationId" : "post-logout-docs",
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json;charset=UTF-8" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/api-v1-routines-daily-member-routine-routineId594740350"
+                },
+                "examples" : {
+                  "post-logout-docs" : {
+                    "value" : "{\n  \"success\" : true,\n  \"message\" : \"로그아웃 성공\",\n  \"data\" : null\n}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/members/{cottonType}" : {
+      "patch" : {
+        "tags" : [ "MEMBER" ],
+        "summary" : "솜뭉치 주기",
+        "description" : "솜뭉치 주기",
+        "operationId" : "give-cotton-docs",
+        "parameters" : [ {
+          "name" : "cottonType",
+          "in" : "path",
+          "description" : "솜뭉치 종류",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json;charset=UTF-8" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/api-v1-members-cottonType-1561973557"
+                },
+                "examples" : {
+                  "give-cotton-docs" : {
+                    "value" : "{\n  \"success\" : true,\n  \"message\" : \"솜뭉치 주기 성공\",\n  \"data\" : {\n    \"cottonCount\" : 0\n  }\n}"
                   }
                 }
               }
@@ -422,6 +504,60 @@
   },
   "components" : {
     "schemas" : {
+      "api-v1-members-980081866" : {
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "type" : "object",
+            "properties" : {
+              "dailyCottonCount" : {
+                "type" : "number",
+                "description" : "솜뭉치 개수"
+              },
+              "name" : {
+                "type" : "string",
+                "description" : "인형 이름"
+              },
+              "frameImageUrl" : {
+                "type" : "string",
+                "description" : "인형 배경 이미지 url"
+              },
+              "dollType" : {
+                "type" : "string",
+                "description" : "인형 종류"
+              },
+              "conversations" : {
+                "type" : "array",
+                "description" : "인형 대화 리스트",
+                "items" : {
+                  "oneOf" : [ {
+                    "type" : "object"
+                  }, {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string"
+                  }, {
+                    "type" : "number"
+                  } ]
+                }
+              },
+              "happinessCottonCount" : {
+                "type" : "number",
+                "description" : "행운 솜뭉치 개수"
+              }
+            },
+            "description" : "응답 데이터"
+          },
+          "success" : {
+            "type" : "boolean",
+            "description" : "응답 성공 여부"
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "응답 메시지"
+          }
+        }
+      },
       "api-v1-routines-daily-theme-themeId-54531209" : {
         "type" : "object",
         "properties" : {
@@ -497,6 +633,29 @@
                     }
                   }
                 }
+              }
+            },
+            "description" : "응답 데이터"
+          },
+          "success" : {
+            "type" : "boolean",
+            "description" : "응답 성공 여부"
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "응답 메시지"
+          }
+        }
+      },
+      "api-v1-members-cottonType-1561973557" : {
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "type" : "object",
+            "properties" : {
+              "cottonCount" : {
+                "type" : "number",
+                "description" : "남은 솜뭉치 개수"
               }
             },
             "description" : "응답 데이터"
@@ -696,6 +855,34 @@
           }
         }
       },
+      "api-v1-members-2061462562" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "인형 이름"
+          },
+          "routines" : {
+            "type" : "array",
+            "description" : "인형 종류",
+            "items" : {
+              "oneOf" : [ {
+                "type" : "object"
+              }, {
+                "type" : "boolean"
+              }, {
+                "type" : "string"
+              }, {
+                "type" : "number"
+              } ]
+            }
+          },
+          "dollType" : {
+            "type" : "string",
+            "description" : "인형 종류"
+          }
+        }
+      },
       "api-v1-routines-daily-member-336344243" : {
         "type" : "object",
         "properties" : {
@@ -741,34 +928,6 @@
           "message" : {
             "type" : "string",
             "description" : "응답 메시지"
-          }
-        }
-      },
-      "api-v1-members-2061462562" : {
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string",
-            "description" : "인형 이름"
-          },
-          "routines" : {
-            "type" : "array",
-            "description" : "인형 종류",
-            "items" : {
-              "oneOf" : [ {
-                "type" : "object"
-              }, {
-                "type" : "boolean"
-              }, {
-                "type" : "string"
-              }, {
-                "type" : "number"
-              } ]
-            }
-          },
-          "dollType" : {
-            "type" : "string",
-            "description" : "인형 종류"
           }
         }
       },


### PR DESCRIPTION
## ✨ Related Issue
- close #101 
  <br/>

## 📝 기능 구현 명세
<img width="1007" alt="image" src="https://github.com/Team-Sopetit/Sopetit-server/assets/55437339/5aa8d1b4-a985-4a14-abd2-a367d0fb2288">
<img width="985" alt="image" src="https://github.com/Team-Sopetit/Sopetit-server/assets/55437339/3fa16d46-753f-4404-b5ed-782b12075235">


## 🐥 추가적인 언급 사항
- 행복 루틴의 전체 조회를 허용하기 위해 themeId 값을 파라미터 값에서 쿼리 값으로 변경했습니다.