### PR TITLE
[ADD] 회원 행복루틴 조회, 204 분기 처리 추가

### DIFF
--- a/src/main/java/com/soptie/server/memberRoutine/controller/MemberHappinessRoutineController.java
+++ b/src/main/java/com/soptie/server/memberRoutine/controller/MemberHappinessRoutineController.java
@@ -3,6 +3,8 @@ package com.soptie.server.memberRoutine.controller;
 import com.soptie.server.common.dto.Response;
 import com.soptie.server.memberRoutine.dto.MemberHappinessRoutineRequest;
 import com.soptie.server.memberRoutine.service.MemberHappinessRoutineService;
+
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 
@@ -15,7 +17,6 @@ import java.security.Principal;
 
 import static com.soptie.server.common.dto.Response.success;
 import static com.soptie.server.memberRoutine.message.SuccessMessage.*;
-import static org.springframework.http.HttpStatus.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -43,13 +44,12 @@ public class MemberHappinessRoutineController {
     }
 
     @GetMapping
-    public ResponseEntity<Response> getMemberHappinessRoutine(Principal principal) {
+    public ResponseEntity<Response> getMemberHappinessRoutine(@NonNull Principal principal) {
         val memberId = Long.parseLong(principal.getName());
         val response = memberHappinessRoutineService.getMemberHappinessRoutine(memberId);
-        val message = SUCCESS_GET_ROUTINE.getMessage();
 		return response
-                .map(routineResponse -> ResponseEntity.ok(success(message, routineResponse)))
-				.orElseGet(() -> ResponseEntity.status(NO_CONTENT).body(success(message)));
+                .map(result -> ResponseEntity.ok(success(SUCCESS_GET_ROUTINE.getMessage(), result)))
+				.orElseGet(() -> ResponseEntity.noContent().build());
 	}
 
     @DeleteMapping("/routine/{routineId}")

--- a/src/main/java/com/soptie/server/memberRoutine/controller/MemberHappinessRoutineController.java
+++ b/src/main/java/com/soptie/server/memberRoutine/controller/MemberHappinessRoutineController.java
@@ -5,6 +5,7 @@ import com.soptie.server.memberRoutine.dto.MemberHappinessRoutineRequest;
 import com.soptie.server.memberRoutine.service.MemberHappinessRoutineService;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -14,6 +15,7 @@ import java.security.Principal;
 
 import static com.soptie.server.common.dto.Response.success;
 import static com.soptie.server.memberRoutine.message.SuccessMessage.*;
+import static org.springframework.http.HttpStatus.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -44,8 +46,11 @@ public class MemberHappinessRoutineController {
     public ResponseEntity<Response> getMemberHappinessRoutine(Principal principal) {
         val memberId = Long.parseLong(principal.getName());
         val response = memberHappinessRoutineService.getMemberHappinessRoutine(memberId);
-        return ResponseEntity.ok(success(SUCCESS_GET_ROUTINE.getMessage(), response));
-    }
+        val message = SUCCESS_GET_ROUTINE.getMessage();
+		return response
+                .map(routineResponse -> ResponseEntity.ok(success(message, routineResponse)))
+				.orElseGet(() -> ResponseEntity.status(NO_CONTENT).body(success(message)));
+	}
 
     @DeleteMapping("/routine/{routineId}")
     public ResponseEntity<Response> deleteMemberHappinessRoutine(Principal principal, @PathVariable Long routineId) {

--- a/src/main/java/com/soptie/server/memberRoutine/service/MemberHappinessRoutineService.java
+++ b/src/main/java/com/soptie/server/memberRoutine/service/MemberHappinessRoutineService.java
@@ -1,12 +1,14 @@
 package com.soptie.server.memberRoutine.service;
 
+import java.util.Optional;
+
 import com.soptie.server.memberRoutine.dto.*;
 import com.soptie.server.memberRoutine.entity.happiness.MemberHappinessRoutine;
 
 public interface MemberHappinessRoutineService {
 
 	MemberHappinessRoutineResponse createMemberHappinessRoutine(long memberId, MemberHappinessRoutineRequest request);
-	MemberHappinessRoutinesResponse getMemberHappinessRoutine(long memberId);
+	Optional<MemberHappinessRoutinesResponse> getMemberHappinessRoutine(long memberId);
 	void deleteMemberHappinessRoutine(long memberId, Long routineId);
 	void achieveMemberHappinessRoutine(long memberId, Long routineId);
 	void deleteMemberHappinessRoutine(MemberHappinessRoutine routine);

--- a/src/main/java/com/soptie/server/memberRoutine/service/MemberHappinessRoutineServiceImpl.java
+++ b/src/main/java/com/soptie/server/memberRoutine/service/MemberHappinessRoutineServiceImpl.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.soptie.server.member.message.ErrorCode.*;
 import static com.soptie.server.routine.message.ErrorCode.*;
@@ -53,10 +54,14 @@ public class MemberHappinessRoutineServiceImpl implements MemberHappinessRoutine
     }
 
     @Override
-    public MemberHappinessRoutinesResponse getMemberHappinessRoutine(long memberId) {
+    public Optional<MemberHappinessRoutinesResponse> getMemberHappinessRoutine(long memberId) {
         val member = findMember(memberId);
         val memberRoutine = member.getHappinessRoutine();
-        return MemberHappinessRoutinesResponse.of(memberRoutine);
+        if (Objects.isNull(memberRoutine)) {
+            return Optional.empty();
+        }
+        val response = MemberHappinessRoutinesResponse.of(memberRoutine);
+        return Optional.of(response);
     }
 
     @Override


### PR DESCRIPTION
## ✨ Related Issue
- close #129 
  <br/>

## 📝 기능 구현 명세
<img width="968" alt="image" src="https://github.com/Team-Sopetit/Sopetit-server/assets/55437339/04e90d21-d630-4d63-8d21-6aa614079756">

## 🐥 추가적인 언급 사항
- 행복 루틴 조회에서 데이터가 없을 경우를 고려하지 않아, 분기 처리를 추가했습니다.