### PR TITLE
[FIX] 테마별 데일리 루틴 조회 수정

### DIFF
--- a/src/main/java/com/soptie/server/memberRoutine/service/MemberDailyRoutineService.java
+++ b/src/main/java/com/soptie/server/memberRoutine/service/MemberDailyRoutineService.java
@@ -6,6 +6,7 @@ import com.soptie.server.memberRoutine.dto.MemberDailyRoutineRequest;
 import com.soptie.server.memberRoutine.dto.MemberDailyRoutineResponse;
 import com.soptie.server.memberRoutine.dto.MemberDailyRoutinesResponse;
 import com.soptie.server.memberRoutine.entity.daily.MemberDailyRoutine;
+import com.soptie.server.routine.entity.daily.DailyRoutine;
 
 import java.util.List;
 
@@ -17,4 +18,5 @@ public interface MemberDailyRoutineService {
 	MemberDailyRoutinesResponse getMemberDailyRoutines(long memberId);
 	void initMemberDailyRoutines();
 	void deleteMemberDailyRoutine(MemberDailyRoutine routine);
+	boolean isExistRoutine(Member member, DailyRoutine routine);
 }

--- a/src/main/java/com/soptie/server/memberRoutine/service/MemberDailyRoutineServiceImpl.java
+++ b/src/main/java/com/soptie/server/memberRoutine/service/MemberDailyRoutineServiceImpl.java
@@ -58,7 +58,8 @@ public class MemberDailyRoutineServiceImpl implements MemberDailyRoutineService 
 		}
 	}
 
-	private boolean isExistRoutine(Member member, DailyRoutine routine) {
+	@Override
+	public boolean isExistRoutine(Member member, DailyRoutine routine) {
 		return memberDailyRoutineRepository.existsByMemberAndRoutine(member, routine);
 	}
 

--- a/src/main/java/com/soptie/server/routine/controller/DailyRoutineController.java
+++ b/src/main/java/com/soptie/server/routine/controller/DailyRoutineController.java
@@ -3,6 +3,7 @@ package com.soptie.server.routine.controller;
 import static com.soptie.server.common.dto.Response.*;
 import static com.soptie.server.routine.message.SuccessMessage.*;
 
+import java.security.Principal;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
@@ -37,8 +38,9 @@ public class DailyRoutineController {
 	}
 
 	@GetMapping("/theme/{themeId}")
-	public ResponseEntity<Response> getRoutinesByTheme(@PathVariable long themeId) {
-		val response = dailyRoutineService.getRoutinesByTheme(themeId);
+	public ResponseEntity<Response> getRoutinesByTheme(Principal principal, @PathVariable long themeId) {
+		val memberId = Long.valueOf(principal.getName());
+		val response = dailyRoutineService.getRoutinesByTheme(memberId, themeId);
 		return ResponseEntity.ok(success(SUCCESS_GET_ROUTINE.getMessage(), response));
 	}
 }

--- a/src/main/java/com/soptie/server/routine/service/DailyRoutineService.java
+++ b/src/main/java/com/soptie/server/routine/service/DailyRoutineService.java
@@ -10,5 +10,5 @@ public interface DailyRoutineService {
 
 	DailyThemesResponse getThemes();
 	DailyRoutinesByThemesResponse getRoutinesByThemes(List<Long> themeIds);
-	DailyRoutinesByThemeResponse getRoutinesByTheme(long themeId);
+	DailyRoutinesByThemeResponse getRoutinesByTheme(long memberId, long themeId);
 }

--- a/src/main/java/com/soptie/server/routine/service/DailyRoutineServiceImpl.java
+++ b/src/main/java/com/soptie/server/routine/service/DailyRoutineServiceImpl.java
@@ -1,5 +1,6 @@
 package com.soptie.server.routine.service;
 
+import static com.soptie.server.member.message.ErrorCode.*;
 import static com.soptie.server.routine.message.ErrorCode.*;
 
 import java.util.List;
@@ -7,9 +8,14 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.soptie.server.member.entity.Member;
+import com.soptie.server.member.exception.MemberException;
+import com.soptie.server.member.repository.MemberRepository;
+import com.soptie.server.memberRoutine.service.MemberDailyRoutineService;
 import com.soptie.server.routine.dto.DailyRoutinesByThemeResponse;
 import com.soptie.server.routine.dto.DailyRoutinesByThemesResponse;
 import com.soptie.server.routine.dto.DailyThemesResponse;
+import com.soptie.server.routine.entity.daily.DailyRoutine;
 import com.soptie.server.routine.entity.daily.DailyTheme;
 import com.soptie.server.routine.exception.RoutineException;
 import com.soptie.server.routine.repository.daily.routine.DailyRoutineRepository;
@@ -24,6 +30,8 @@ public class DailyRoutineServiceImpl implements DailyRoutineService {
 
 	private final DailyThemeRepository dailyThemeRepository;
 	private final DailyRoutineRepository dailyRoutineRepository;
+	private final MemberRepository memberRepository;
+	private final MemberDailyRoutineService memberDailyRoutineService;
 
 	@Override
 	public DailyThemesResponse getThemes() {
@@ -38,14 +46,26 @@ public class DailyRoutineServiceImpl implements DailyRoutineService {
 	}
 
 	@Override
-	public DailyRoutinesByThemeResponse getRoutinesByTheme(long themeId) {
+	public DailyRoutinesByThemeResponse getRoutinesByTheme(long memberId, long themeId) {
+		val member = findMember(memberId);
 		val theme = findTheme(themeId);
-		val routines = dailyRoutineRepository.findAllByTheme(theme);
+		val routines = getRoutines(member, theme);
 		return DailyRoutinesByThemeResponse.of(theme, routines);
+	}
+
+	private Member findMember(long id) {
+		return memberRepository.findById(id)
+				.orElseThrow(() -> new MemberException(INVALID_MEMBER));
 	}
 
 	private DailyTheme findTheme(long id) {
 		return dailyThemeRepository.findById(id)
-			.orElseThrow(() -> new RoutineException(INVALID_THEME));
+				.orElseThrow(() -> new RoutineException(INVALID_THEME));
+	}
+
+	private List<DailyRoutine> getRoutines(Member member, DailyTheme theme) {
+		return dailyRoutineRepository.findAllByTheme(theme).stream()
+				.filter(routine -> !memberDailyRoutineService.isExistRoutine(member, routine))
+				.toList();
 	}
 }

--- a/src/test/java/com/soptie/server/routine/controller/DailyRoutineControllerTest.java
+++ b/src/test/java/com/soptie/server/routine/controller/DailyRoutineControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.security.Principal;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -34,6 +35,8 @@ class DailyRoutineControllerTest extends BaseControllerTest {
 
 	@MockBean
 	DailyRoutineController controller;
+	@MockBean
+	Principal principal;
 
 	private final String DEFAULT_URL = "/api/v1/routines/daily";
 	private final String TAG = "DAILY ROUTINE";
@@ -128,18 +131,20 @@ class DailyRoutineControllerTest extends BaseControllerTest {
 	@DisplayName("테마 별 데일리 루틴 리스트 조회 성공")
 	void success_getDailyRoutinesByTheme() throws Exception {
 		// given
+		long themeId = 1L;
 		DailyRoutinesByThemeResponse routines = DailyRoutineFixture.createDailyRoutinesByThemeResponseDTO();
 		ResponseEntity<Response> response = ResponseEntity.ok(Response.success("루틴 조회 성공", routines));
 
 		// when
-		when(controller.getRoutinesByTheme(anyLong())).thenReturn(response);
+		when(controller.getRoutinesByTheme(principal, themeId)).thenReturn(response);
 
 		// then
 		mockMvc
 			.perform(
 				RestDocumentationRequestBuilders.get(DEFAULT_URL + "/theme/{themeId}", 1L)
 					.contentType(MediaType.APPLICATION_JSON)
-					.accept(MediaType.APPLICATION_JSON))
+					.accept(MediaType.APPLICATION_JSON)
+					.principal(principal))
 			.andDo(
 				MockMvcRestDocumentation.document(
 					"get-theme-daily-routines-docs",


### PR DESCRIPTION
## ✨ Related Issue
- close #154 
  <br/>

## 📝 기능 구현 명세
<img width="1016" alt="image" src="https://github.com/Team-Sopetit/Sopetit-server/assets/55437339/d41cbb6a-caaf-466e-8bef-dc21d20eba97">


## 🐥 추가적인 언급 사항
- 회원이 추가한 데일리 루틴은 조회할 수 없도록 일부 수정했습니다.