### PR TITLE
[FIX] 데일리 솜뭉치 무한 개 생성 막기

### DIFF
--- a/src/main/java/com/soptie/server/memberRoutine/entity/daily/CompletedMemberDailyRoutine.java
+++ b/src/main/java/com/soptie/server/memberRoutine/entity/daily/CompletedMemberDailyRoutine.java
@@ -1,5 +1,9 @@
 package com.soptie.server.memberRoutine.entity.daily;
 
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+
 import com.soptie.server.member.entity.Member;
 import com.soptie.server.routine.entity.daily.DailyRoutine;
 
@@ -26,6 +30,8 @@ public class CompletedMemberDailyRoutine {
 
 	private int achieveCount;
 
+	private Boolean isAchieve;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
 	private Member member;
@@ -34,8 +40,13 @@ public class CompletedMemberDailyRoutine {
 	@JoinColumn(name = "routine_id")
 	private DailyRoutine routine;
 
+	@CreatedDate
+	@Column(nullable = false)
+	protected LocalDateTime createdAt;
+
 	public CompletedMemberDailyRoutine(MemberDailyRoutine routine) {
 		this.achieveCount = routine.getAchieveCount();
+		this.isAchieve = routine.isAchieve();
 		setMember(routine);
 		this.routine = routine.getRoutine();
 	}

--- a/src/main/java/com/soptie/server/memberRoutine/entity/daily/CompletedMemberDailyRoutine.java
+++ b/src/main/java/com/soptie/server/memberRoutine/entity/daily/CompletedMemberDailyRoutine.java
@@ -3,12 +3,14 @@ package com.soptie.server.memberRoutine.entity.daily;
 import java.time.LocalDateTime;
 
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.soptie.server.member.entity.Member;
 import com.soptie.server.routine.entity.daily.DailyRoutine;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -21,6 +23,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor
 @Getter
+@EntityListeners(AuditingEntityListener.class)
 public class CompletedMemberDailyRoutine {
 
 	@Id
@@ -41,7 +44,6 @@ public class CompletedMemberDailyRoutine {
 	private DailyRoutine routine;
 
 	@CreatedDate
-	@Column(nullable = false)
 	protected LocalDateTime createdAt;
 
 	public CompletedMemberDailyRoutine(MemberDailyRoutine routine) {

--- a/src/main/java/com/soptie/server/memberRoutine/entity/daily/MemberDailyRoutine.java
+++ b/src/main/java/com/soptie/server/memberRoutine/entity/daily/MemberDailyRoutine.java
@@ -52,6 +52,13 @@ public class MemberDailyRoutine {
 		this.routine = routine;
 	}
 
+	public MemberDailyRoutine(Member member, DailyRoutine routine, int achieveCount, boolean isAchieve) {
+		this.achieveCount = achieveCount;
+		this.isAchieve = isAchieve;
+		setMember(member);
+		this.routine = routine;
+	}
+
 	private void setMember(Member member) {
 		if (Objects.nonNull(this.member)) {
 			this.member.getDailyRoutines().remove(this);

--- a/src/main/java/com/soptie/server/memberRoutine/service/MemberDailyRoutineServiceImpl.java
+++ b/src/main/java/com/soptie/server/memberRoutine/service/MemberDailyRoutineServiceImpl.java
@@ -23,6 +23,7 @@ import com.soptie.server.routine.repository.daily.routine.DailyRoutineRepository
 
 import lombok.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -64,9 +65,19 @@ public class MemberDailyRoutineServiceImpl implements MemberDailyRoutineService 
 
 	private MemberDailyRoutine recreateOldRoutines(
 			Member member, DailyRoutine routine, CompletedMemberDailyRoutine completedRoutine) {
+		val isTodayAchieved = isTodayAchieved(completedRoutine);
 		completedMemberDailyRoutineRepository.delete(completedRoutine);
-		return memberDailyRoutineRepository
-				.save(new MemberDailyRoutine(member, routine, completedRoutine.getAchieveCount()));
+		val memberRoutine = new MemberDailyRoutine(member, routine, completedRoutine.getAchieveCount(), isTodayAchieved);
+		return memberDailyRoutineRepository.save(memberRoutine);
+	}
+
+	private boolean isTodayAchieved(CompletedMemberDailyRoutine completedRoutine) {
+		return completedRoutine.getIsAchieve() && isTodayCompleted(completedRoutine);
+	}
+
+	private boolean isTodayCompleted(CompletedMemberDailyRoutine completedRoutine) {
+		val now = LocalDate.now();
+		return completedRoutine.getCreatedAt().toLocalDate().equals(now);
 	}
 
 	@Override


### PR DESCRIPTION
## ✨ Related Issue
- close #160 
  <br/>

## 📝 기능 구현 명세
<img width="959" alt="image" src="https://github.com/Team-Sopetit/Sopetit-server/assets/55437339/49b928ba-0b0e-4daa-8768-fa3fd2378232">
<img width="972" alt="image" src="https://github.com/Team-Sopetit/Sopetit-server/assets/55437339/e6207f80-ab07-48a3-8452-bc1f45d3d7d9">


## 🐥 추가적인 언급 사항
- 솜뭉치 무한 생성을 막기 위해, 오늘 달성하고 삭제한 데일리 루틴은 다시 추가해도 달성 완료된 루틴으로 추가합니다.