### PR TITLE
[ADD] 회원 데일리 루틴 정렬 조건 추가

### DIFF
--- a/src/main/java/com/soptie/server/memberRoutine/repository/MemberDailyRoutineRepositoryImpl.java
+++ b/src/main/java/com/soptie/server/memberRoutine/repository/MemberDailyRoutineRepositoryImpl.java
@@ -31,6 +31,7 @@ public class MemberDailyRoutineRepositoryImpl implements MemberDailyRoutineCusto
 			.leftJoin(memberDailyRoutine.routine, dailyRoutine).fetchJoin()
 			.leftJoin(dailyRoutine.theme, dailyTheme).fetchJoin()
 			.orderBy(
+				memberDailyRoutine.isAchieve.asc(),
 				memberDailyRoutine.achieveCount.desc(),
 				contentInKRExpression.asc()
 			)


### PR DESCRIPTION
## ✨ Related Issue
- close #164
  <br/>

## 📝 기능 구현 명세
<img width="1010" alt="image" src="https://github.com/Team-Sopetit/Sopetit-server/assets/55437339/48529479-9b1d-477b-9801-f102551965d0">


- 달성 완료되지 않은(false) 루틴 먼저
- 달성 횟수 많은 루틴 먼저
- 가나다 순

## 🐥 추가적인 언급 사항
- 안드로이드 apk 과제 진행 종료 후(1/20 1시 예정) 배포합니다.