### PR TITLE
[FIX] 업데이트 알림 문구 수정

### DIFF
--- a/src/main/java/com/soptie/server/common/config/ValueConfig.java
+++ b/src/main/java/com/soptie/server/common/config/ValueConfig.java
@@ -39,9 +39,9 @@ public class ValueConfig {
     @Value("${jwt.REFRESH_TOKEN_EXPIRED}")
     private Long refreshTokenExpired;
 
-    private final String IOS_FORCE_UPDATE_VERSION = "1.0.0";
+    private final String IOS_FORCE_UPDATE_VERSION = "0.0.9";
     private final String IOS_APP_VERSION = "1.0.0";
-    private final String ANDROID_FORCE_UPDATE_VERSION = "1.0.0";
+    private final String ANDROID_FORCE_UPDATE_VERSION = "0.0.9";
     private final String ANDROID_APP_VERSION = "1.0.0";
     private final String NOTIFICATION_TITLE = "새로운 버전이 업데이트 되었어요!";
     private final String NOTIFICATION_CONTENT = "안정적인 서비스 사용을 위해\n최신버전으로 업데이트 해주세요.";

--- a/src/main/java/com/soptie/server/common/config/ValueConfig.java
+++ b/src/main/java/com/soptie/server/common/config/ValueConfig.java
@@ -43,7 +43,8 @@ public class ValueConfig {
     private final String IOS_APP_VERSION = "1.0.0";
     private final String ANDROID_FORCE_UPDATE_VERSION = "1.0.0";
     private final String ANDROID_APP_VERSION = "1.0.0";
-    private final String NOTIFICATION_CONTENT = "소프티의 새로운 버전이 출시되었어요.\n업데이트 후 이용해 주세요.";
+    private final String NOTIFICATION_TITLE = "새로운 버전이 업데이트 되었어요!";
+    private final String NOTIFICATION_CONTENT = "안정적인 서비스 사용을 위해\n최신버전으로 업데이트 해주세요.";
     private final String TOKEN_VALUE_DELIMITER = "\\.";
     private final String BEARER_HEADER = "Bearer ";
     private final String BLANK = "";

--- a/src/main/java/com/soptie/server/version/dto/AppVersionResponse.java
+++ b/src/main/java/com/soptie/server/version/dto/AppVersionResponse.java
@@ -7,14 +7,16 @@ import lombok.Builder;
 public record AppVersionResponse(
 		VersionResponse iosVersion,
 		VersionResponse androidVersion,
+		String notificationTitle,
 		String notificationContent
 ) {
 
-	public static AppVersionResponse of(String iOSAppVersion, String iosForceUpdateVersion,
-			String androidAppVersion, String androidForceUpdateVersion, String notificationContent) {
+	public static AppVersionResponse of(String iOSAppVersion, String iosForceUpdateVersion, String androidAppVersion,
+			String androidForceUpdateVersion, String notificationTitle, String notificationContent) {
 		return AppVersionResponse.builder()
 				.iosVersion(new VersionResponse(iOSAppVersion, iosForceUpdateVersion))
 				.androidVersion(new VersionResponse(androidAppVersion, androidForceUpdateVersion))
+				.notificationTitle(notificationTitle)
 				.notificationContent(notificationContent)
 				.build();
 	}

--- a/src/main/java/com/soptie/server/version/service/VersionServiceImpl.java
+++ b/src/main/java/com/soptie/server/version/service/VersionServiceImpl.java
@@ -22,6 +22,7 @@ public class VersionServiceImpl implements VersionService {
 				valueConfig.getIOS_FORCE_UPDATE_VERSION(),
 				valueConfig.getANDROID_APP_VERSION(),
 				valueConfig.getANDROID_FORCE_UPDATE_VERSION(),
+				valueConfig.getNOTIFICATION_TITLE(),
 				valueConfig.getNOTIFICATION_CONTENT());
 	}
 }

--- a/src/main/resources/static/docs/open-api-3.0.1.json
+++ b/src/main/resources/static/docs/open-api-3.0.1.json
@@ -227,40 +227,6 @@
         }
       }
     },
-    "/api/v1/members/{cottonType}" : {
-      "patch" : {
-        "tags" : [ "MEMBER" ],
-        "summary" : "솜뭉치 주기",
-        "description" : "솜뭉치 주기",
-        "operationId" : "give-cotton-docs",
-        "parameters" : [ {
-          "name" : "cottonType",
-          "in" : "path",
-          "description" : "솜뭉치 종류",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "200",
-            "content" : {
-              "application/json;charset=UTF-8" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-members-cottonType-1561973557"
-                },
-                "examples" : {
-                  "give-cotton-docs" : {
-                    "value" : "{\n  \"success\" : true,\n  \"message\" : \"솜뭉치 주기 성공\",\n  \"data\" : {\n    \"cottonCount\" : 0\n  }\n}"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v1/routines/daily" : {
       "get" : {
         "tags" : [ "DAILY ROUTINE" ],
@@ -355,6 +321,40 @@
                 "examples" : {
                   "get-doll-image-docs" : {
                     "value" : "{\n  \"success\" : true,\n  \"message\" : \"인형 이미지 조회 성공\",\n  \"data\" : {\n    \"faceImageUrl\" : \"face-image-url\"\n  }\n}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/members/cotton/{cottonType}" : {
+      "patch" : {
+        "tags" : [ "MEMBER" ],
+        "summary" : "솜뭉치 주기",
+        "description" : "솜뭉치 주기",
+        "operationId" : "give-cotton-docs",
+        "parameters" : [ {
+          "name" : "cottonType",
+          "in" : "path",
+          "description" : "솜뭉치 종류",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json;charset=UTF-8" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/api-v1-members-cotton-cottonType-1561973557"
+                },
+                "examples" : {
+                  "give-cotton-docs" : {
+                    "value" : "{\n  \"success\" : true,\n  \"message\" : \"솜뭉치 주기 성공\",\n  \"data\" : {\n    \"cottonCount\" : 0\n  }\n}"
                   }
                 }
               }
@@ -597,11 +597,11 @@
             "content" : {
               "application/json;charset=UTF-8" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-versions-client-app-914728397"
+                  "$ref" : "#/components/schemas/api-v1-versions-client-app2103188655"
                 },
                 "examples" : {
                   "get-client-app-version-docs" : {
-                    "value" : "{\n  \"success\" : true,\n  \"message\" : \"버전 조회 성공\",\n  \"data\" : {\n    \"iosVersion\" : {\n      \"appVersion\" : \"1.0.0\",\n      \"forceUpdateVersion\" : \"1.0.0\"\n    },\n    \"androidVersion\" : {\n      \"appVersion\" : \"1.0.0\",\n      \"forceUpdateVersion\" : \"1.0.0\"\n    },\n    \"notificationContent\" : \"업데이트가 필요합니다.\"\n  }\n}"
+                    "value" : "{\n  \"success\" : true,\n  \"message\" : \"버전 조회 성공\",\n  \"data\" : {\n    \"iosVersion\" : {\n      \"appVersion\" : \"1.0.0\",\n      \"forceUpdateVersion\" : \"1.0.0\"\n    },\n    \"androidVersion\" : {\n      \"appVersion\" : \"1.0.0\",\n      \"forceUpdateVersion\" : \"1.0.0\"\n    },\n    \"notificationTitle\" : \"업데이트 안내\",\n    \"notificationContent\" : \"업데이트가 필요합니다.\"\n  }\n}"
                   }
                 }
               }
@@ -894,57 +894,6 @@
           }
         }
       },
-      "api-v1-versions-client-app-914728397" : {
-        "type" : "object",
-        "properties" : {
-          "data" : {
-            "type" : "object",
-            "properties" : {
-              "androidVersion" : {
-                "type" : "object",
-                "properties" : {
-                  "appVersion" : {
-                    "type" : "string",
-                    "description" : "안드로이드 앱 버전"
-                  },
-                  "forceUpdateVersion" : {
-                    "type" : "string",
-                    "description" : "안드로이드 강제 업데이트 버전"
-                  }
-                },
-                "description" : "안드로이드 버전 정보"
-              },
-              "iosVersion" : {
-                "type" : "object",
-                "properties" : {
-                  "appVersion" : {
-                    "type" : "string",
-                    "description" : "iOS 앱 버전"
-                  },
-                  "forceUpdateVersion" : {
-                    "type" : "string",
-                    "description" : "iOS 강제 업데이트 버전"
-                  }
-                },
-                "description" : "iOS 버전 정보"
-              },
-              "notificationContent" : {
-                "type" : "string",
-                "description" : "업데이트 알림 내용"
-              }
-            },
-            "description" : "응답 데이터"
-          },
-          "success" : {
-            "type" : "boolean",
-            "description" : "응답 성공 여부"
-          },
-          "message" : {
-            "type" : "string",
-            "description" : "응답 메시지"
-          }
-        }
-      },
       "api-v1-routines-daily-member1721287602" : {
         "type" : "object",
         "properties" : {
@@ -1087,7 +1036,7 @@
           }
         }
       },
-      "api-v1-members-cottonType-1561973557" : {
+      "api-v1-members-cotton-cottonType-1561973557" : {
         "type" : "object",
         "properties" : {
           "data" : {
@@ -1258,6 +1207,61 @@
               "title" : {
                 "type" : "string",
                 "description" : "행복 루틴 주제"
+              }
+            },
+            "description" : "응답 데이터"
+          },
+          "success" : {
+            "type" : "boolean",
+            "description" : "응답 성공 여부"
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "응답 메시지"
+          }
+        }
+      },
+      "api-v1-versions-client-app2103188655" : {
+        "type" : "object",
+        "properties" : {
+          "data" : {
+            "type" : "object",
+            "properties" : {
+              "notificationTitle" : {
+                "type" : "string",
+                "description" : "업데이트 알림 제목"
+              },
+              "androidVersion" : {
+                "type" : "object",
+                "properties" : {
+                  "appVersion" : {
+                    "type" : "string",
+                    "description" : "안드로이드 앱 버전"
+                  },
+                  "forceUpdateVersion" : {
+                    "type" : "string",
+                    "description" : "안드로이드 강제 업데이트 버전"
+                  }
+                },
+                "description" : "안드로이드 버전 정보"
+              },
+              "iosVersion" : {
+                "type" : "object",
+                "properties" : {
+                  "appVersion" : {
+                    "type" : "string",
+                    "description" : "iOS 앱 버전"
+                  },
+                  "forceUpdateVersion" : {
+                    "type" : "string",
+                    "description" : "iOS 강제 업데이트 버전"
+                  }
+                },
+                "description" : "iOS 버전 정보"
+              },
+              "notificationContent" : {
+                "type" : "string",
+                "description" : "업데이트 알림 내용"
               }
             },
             "description" : "응답 데이터"

--- a/src/test/java/com/soptie/server/version/controller/VersionControllerTest.java
+++ b/src/test/java/com/soptie/server/version/controller/VersionControllerTest.java
@@ -46,6 +46,7 @@ class VersionControllerTest extends BaseControllerTest {
 				"1.0.0",
 				"1.0.0",
 				"1.0.0",
+				"업데이트 안내",
 				"업데이트가 필요합니다.");
 		ResponseEntity<Response> response = ResponseEntity.ok(Response.success("버전 조회 성공", versionInfo));
 
@@ -78,6 +79,7 @@ class VersionControllerTest extends BaseControllerTest {
 														fieldWithPath("data.androidVersion").type(OBJECT).description("안드로이드 버전 정보"),
 														fieldWithPath("data.androidVersion.appVersion").type(STRING).description("안드로이드 앱 버전"),
 														fieldWithPath("data.androidVersion.forceUpdateVersion").type(STRING).description("안드로이드 강제 업데이트 버전"),
+														fieldWithPath("data.notificationTitle").type(STRING).description("업데이트 알림 제목"),
 														fieldWithPath("data.notificationContent").type(STRING).description("업데이트 알림 내용")
 												)
 												.build())))


### PR DESCRIPTION
## ✨ Related Issue
- close #178 
  <br/>

## 📝 기능 구현 명세
<img width="1019" alt="image" src="https://github.com/Team-Sopetit/Sopetit-server/assets/55437339/8fc85844-41c7-4e52-8118-462b0aa7258b">

## 🐥 추가적인 언급 사항
- 기획 요청으로 업데이트 알림 문구를 수정했습니다. ([슬랙 논의 자료](https://w1702988084-f1k570985.slack.com/archives/C06D0RQRNHG/p1706597667893949?thread_ts=1706496474.599839&cid=C06D0RQRNHG))
- 클라 요청으로 업데이트 알림 문구를 title, content로 구분했습니다.