### PR TITLE
[TEST] 데일리 루틴 테마 전체 조회 테스트

### DIFF
--- a/src/main/java/com/soptie/server/routine/entity/daily/DailyTheme.java
+++ b/src/main/java/com/soptie/server/routine/entity/daily/DailyTheme.java
@@ -24,4 +24,10 @@ public class DailyTheme {
 		this.name = name;
 		this.imageInfo = imageInfo;
 	}
+
+	public DailyTheme(Long id, String name, String iconImageUrl, String backgroundImageUrl) {
+		this.id = id;
+		this.name = name;
+		this.imageInfo = new RoutineImage(iconImageUrl, backgroundImageUrl);
+	}
 }

--- a/src/test/java/com/soptie/server/routine/repository/daily/theme/DailyThemeRepositoryTest.java
+++ b/src/test/java/com/soptie/server/routine/repository/daily/theme/DailyThemeRepositoryTest.java
@@ -1,0 +1,37 @@
+package com.soptie.server.routine.repository.daily.theme;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.soptie.server.routine.entity.daily.DailyTheme;
+import com.soptie.server.support.DailyThemeFixture;
+import com.soptie.server.support.RepositoryTest;
+
+@RepositoryTest
+class DailyThemeRepositoryTest {
+
+	@Autowired
+	DailyThemeRepository dailyThemeRepository;
+
+	@Test
+	void findAllThemes_success() {
+		// given
+		String imageUrl = "https://www...";
+		dailyThemeRepository.save(DailyThemeFixture.dailyTheme().id(1L).name("소현 서버").imageUrl(imageUrl).build());
+		dailyThemeRepository.save(DailyThemeFixture.dailyTheme().id(2L).name("찬 서버").imageUrl(imageUrl).build());
+		dailyThemeRepository.save(DailyThemeFixture.dailyTheme().id(3L).name("승빈 서버").imageUrl(imageUrl).build());
+
+		// when
+		List<DailyTheme> actual = dailyThemeRepository.findAllOrderByNameAsc();
+
+		// then
+		assertThat(actual).hasSize(3);
+		assertThat(actual.get(0).getName()).isEqualTo("소현 서버");
+		assertThat(actual.get(1).getName()).isEqualTo("승빈 서버");
+		assertThat(actual.get(2).getName()).isEqualTo("찬 서버");
+	}
+}

--- a/src/test/java/com/soptie/server/routine/service/DailyRoutineServiceImplTest.java
+++ b/src/test/java/com/soptie/server/routine/service/DailyRoutineServiceImplTest.java
@@ -1,0 +1,51 @@
+package com.soptie.server.routine.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.soptie.server.routine.dto.DailyThemesResponse;
+import com.soptie.server.routine.dto.DailyThemesResponse.DailyThemeResponse;
+import com.soptie.server.routine.entity.daily.DailyTheme;
+import com.soptie.server.routine.repository.daily.theme.DailyThemeRepository;
+import com.soptie.server.support.DailyThemeFixture;
+
+@ExtendWith(MockitoExtension.class)
+class DailyRoutineServiceImplTest {
+
+	@InjectMocks
+	private DailyRoutineServiceImpl dailyRoutineService;
+
+	@Mock
+	private DailyThemeRepository dailyThemeRepository;
+
+	@DisplayName("데일리 루틴 테마 목록 조회 성공")
+	@Test
+	void getAllThemes_success() {
+		// given
+		doReturn(dailyThemes()).when(dailyThemeRepository).findAllOrderByNameAsc();
+
+		// when
+		final DailyThemesResponse actual = dailyRoutineService.getThemes();
+
+		// then
+		List<Long> themeIds = actual.themes().stream().map(DailyThemeResponse::themeId).toList();
+		assertThat(themeIds).containsExactlyInAnyOrder(1L, 2L);
+	}
+
+	private List<DailyTheme> dailyThemes() {
+		String imageUrl = "https://www...";
+		return List.of(
+				DailyThemeFixture.dailyTheme().id(1L).name("theme1").imageUrl(imageUrl).build(),
+				DailyThemeFixture.dailyTheme().id(2L).name("theme2").imageUrl(imageUrl).build()
+		);
+	}
+}

--- a/src/test/java/com/soptie/server/support/DailyThemeFixture.java
+++ b/src/test/java/com/soptie/server/support/DailyThemeFixture.java
@@ -1,0 +1,39 @@
+package com.soptie.server.support;
+
+import com.soptie.server.routine.entity.daily.DailyRoutine;
+import com.soptie.server.routine.entity.daily.DailyTheme;
+
+public class DailyThemeFixture {
+
+	private Long id;
+	private String name;
+	private String iconImageUrl;
+	private String backgroundImageUrl;
+
+	private DailyThemeFixture() {
+	}
+
+	public static DailyThemeFixture dailyTheme() {
+		return new DailyThemeFixture();
+	}
+
+	public DailyThemeFixture id(Long id) {
+		this.id = id;
+		return this;
+	}
+
+	public DailyThemeFixture name(String name) {
+		this.name = name;
+		return this;
+	}
+
+	public DailyThemeFixture imageUrl(String imageUrl) {
+		this.iconImageUrl = imageUrl;
+		this.backgroundImageUrl = imageUrl;
+		return this;
+	}
+
+	public DailyTheme build() {
+		return new DailyTheme(id, name, iconImageUrl, backgroundImageUrl);
+	}
+}

--- a/src/test/java/com/soptie/server/support/RepositoryTest.java
+++ b/src/test/java/com/soptie/server/support/RepositoryTest.java
@@ -1,0 +1,19 @@
+package com.soptie.server.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.soptie.server.common.config.JpaAuditingConfig;
+import com.soptie.server.common.config.JpaQueryFactoryConfig;
+
+@DataJpaTest(showSql = false)
+@Import({JpaAuditingConfig.class, JpaQueryFactoryConfig.class})
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface RepositoryTest {
+}


### PR DESCRIPTION
## ✨ Related Issue
none (공통 이슈 사용)
  <br/>

## 📝 기능 구현 명세
![image](https://github.com/Team-Sopetit/Sopetit-server/assets/55437339/e585cf18-9e70-40be-8b2c-328d5262cc45)

## 🐥 추가적인 언급 사항
- Repository 테마 조회 기능 테스트
- Service 테마 조회 기능 테스트
