### PR TITLE
[TEST] MemberDollService 테스트

### DIFF
--- a/src/test/java/com/soptie/server/memberDoll/service/MemberDollServiceImplTest.java
+++ b/src/test/java/com/soptie/server/memberDoll/service/MemberDollServiceImplTest.java
@@ -1,0 +1,53 @@
+package com.soptie.server.memberDoll.service;
+
+import com.soptie.server.doll.entity.Doll;
+import com.soptie.server.doll.repository.DollRepository;
+import com.soptie.server.member.entity.Member;
+import com.soptie.server.memberDoll.repository.MemberDollRepository;
+import com.soptie.server.support.MemberFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.soptie.server.doll.entity.DollType.BROWN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+class MemberDollServiceImplTest {
+
+    @InjectMocks
+    private MemberDollServiceImpl memberDollService;
+
+    @Mock
+    private DollRepository dollRepository;
+
+    @Mock
+    private MemberDollRepository memberDollRepository;
+
+    @Test
+    @DisplayName("멤버 인형을 생성하고 이를 멤버의 멤버 인형으로 설정한다.")
+    void 멤버_인형을_생성하고_이를_멤버의_인형으로_세팅한다() {
+        // given
+        Long id = 1L;
+        String name = "brownie";
+        Member member = member(id);
+        doReturn(Optional.of(new Doll())).when(dollRepository).findByDollType(BROWN);
+
+        // when
+        memberDollService.createMemberDoll(member, BROWN, name);
+
+        // then
+        assertThat(member.getMemberDoll().getName()).isEqualTo(name);
+    }
+
+    private Member member(long memberId) {
+        Member member = MemberFixture.member().id(memberId).build();
+        return member;
+    }
+}


### PR DESCRIPTION
## ✨ Related Issue
- close #205 
  <br/>

## 📝 기능 구현 명세
![image](https://github.com/Team-Sopetit/Sopetit-server/assets/81404890/ba60e4b2-39d4-4aca-9398-dbdf512e9d7d)
- createMemberDoll() 테스트

## 🐥 추가적인 언급 사항

- createMemberDoll()에 void형이라 Member의 memberDoll로 세팅이 됐는지 확인하는 방식으로 테스트를 짰습니다.
- deleteMemberDoll()은 Jpa의 delete를 쓰고 있어서 테스트가 필요하지 않다고 판단하고 코드를 짜지 않았습니다. 
