### PR TITLE
[TEST] MemberService 테스트

### DIFF
--- a/src/main/java/com/soptie/server/conversation/entity/Conversation.java
+++ b/src/main/java/com/soptie/server/conversation/entity/Conversation.java
@@ -5,6 +5,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,10 +15,15 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Conversation {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "conversation_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "conversation_id")
+    private Long id;
 
-	private String content;
+    private String content;
+
+    public Conversation(Long id, String content) {
+        this.id = id;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/soptie/server/doll/entity/Doll.java
+++ b/src/main/java/com/soptie/server/doll/entity/Doll.java
@@ -38,4 +38,10 @@ public class Doll {
 		this.id = id;
 		this.imageInfo = new DollImage(faceImageUrl, "", "");
 	}
+
+	public Doll(Long id, DollType dollType, String faceImageUrl) {
+		this.id = id;
+		this.dollType = dollType;
+		this.imageInfo = new DollImage(faceImageUrl, "", "");
+	}
 }

--- a/src/main/java/com/soptie/server/doll/entity/Doll.java
+++ b/src/main/java/com/soptie/server/doll/entity/Doll.java
@@ -34,11 +34,6 @@ public class Doll {
 		this.imageInfo = imageInfo;
 	}
 
-	public Doll(Long id, String faceImageUrl) {
-		this.id = id;
-		this.imageInfo = new DollImage(faceImageUrl, "", "");
-	}
-
 	public Doll(Long id, DollType dollType, String faceImageUrl) {
 		this.id = id;
 		this.dollType = dollType;

--- a/src/main/java/com/soptie/server/memberDoll/entity/MemberDoll.java
+++ b/src/main/java/com/soptie/server/memberDoll/entity/MemberDoll.java
@@ -52,6 +52,13 @@ public class MemberDoll extends BaseTime {
 		this.id = id;
 	}
 
+	public MemberDoll(Long id, String name, int happinessCottonCount, Doll doll) {
+		this.id = id;
+		this.name = name;
+		this.happinessCottonCount = happinessCottonCount;
+		this.doll = doll;
+	}
+
 	private void setMember(Member member) {
 		this.member = member;
 		member.setMemberDoll(this);

--- a/src/test/java/com/soptie/server/doll/service/DollServiceImplTest.java
+++ b/src/test/java/com/soptie/server/doll/service/DollServiceImplTest.java
@@ -46,7 +46,7 @@ class DollServiceImplTest {
     }
 
     private Doll doll(Long id, DollType dollType, String faceImageUrl) {
-        Doll doll = DollFixture.doll().id(id).faceImageUrl(faceImageUrl).build();
+        Doll doll = DollFixture.doll().id(id).dollType(dollType).faceImageUrl(faceImageUrl).build();
         doReturn(Optional.of(doll)).when(dollRepository).findByDollType(dollType);
         return doll;
     }

--- a/src/test/java/com/soptie/server/member/service/MemberServiceImplTest.java
+++ b/src/test/java/com/soptie/server/member/service/MemberServiceImplTest.java
@@ -14,6 +14,7 @@ import com.soptie.server.memberDoll.entity.MemberDoll;
 import com.soptie.server.memberDoll.service.MemberDollServiceImpl;
 import com.soptie.server.memberRoutine.service.MemberDailyRoutineServiceImpl;
 import com.soptie.server.support.ConversationFixture;
+import com.soptie.server.support.DollFixture;
 import com.soptie.server.support.MemberDollFixture;
 import com.soptie.server.support.MemberFixture;
 import org.junit.jupiter.api.DisplayName;
@@ -106,7 +107,7 @@ class MemberServiceImplTest {
     void 멤버_프로필_정보를_가져온다() {
         // given
         long dollId = 1L;
-        Doll doll = new Doll(dollId, BROWN, "faceImageUrl");
+        Doll doll = doll(dollId, BROWN, "faceImageUrl");
         long memberDollId = 2L;
         MemberDoll memberDoll = memberDoll(memberDollId, "memberDoll", 0, doll);
         long memberId = 3L;
@@ -144,6 +145,11 @@ class MemberServiceImplTest {
         MemberDoll memberDoll = MemberDollFixture.memberDoll().id(memberDollId).name(name)
                 .happinessCottonCount(happinessCottonCount).doll(doll).build();
         return memberDoll;
+    }
+
+    private Doll doll(Long id, DollType dollType, String faceImageUrl) {
+        Doll doll = DollFixture.doll().id(id).dollType(dollType).faceImageUrl(faceImageUrl).build();
+        return doll;
     }
 
     private List<Conversation> conversations(List<Long> conversationIds) {

--- a/src/test/java/com/soptie/server/member/service/MemberServiceImplTest.java
+++ b/src/test/java/com/soptie/server/member/service/MemberServiceImplTest.java
@@ -1,11 +1,14 @@
 package com.soptie.server.member.service;
 
-import com.soptie.server.member.entity.Cotton;
+import com.soptie.server.doll.entity.DollType;
+import com.soptie.server.member.dto.MemberProfileRequest;
 import com.soptie.server.member.entity.CottonType;
 import com.soptie.server.member.entity.Member;
 import com.soptie.server.member.exception.MemberException;
 import com.soptie.server.member.repository.MemberRepository;
 import com.soptie.server.memberDoll.entity.MemberDoll;
+import com.soptie.server.memberDoll.service.MemberDollServiceImpl;
+import com.soptie.server.memberRoutine.service.MemberDailyRoutineServiceImpl;
 import com.soptie.server.support.MemberFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,12 +17,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
+import static com.soptie.server.doll.entity.DollType.BROWN;
 import static com.soptie.server.member.message.ErrorCode.NOT_ENOUGH_COTTON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceImplTest {
@@ -28,7 +33,34 @@ class MemberServiceImplTest {
     private MemberServiceImpl memberService;
 
     @Mock
+    private MemberDailyRoutineServiceImpl memberDailyRoutineService;
+
+    @Mock
+    private MemberDollServiceImpl memberDollService;
+
+    @Mock
     private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("멤버 프로필 생성 시, 멤버 데일리 루틴 생성과 멤버 인형 생성 메소드를 호출한다.")
+    void 멤버_프로필을_생성하면서_멤버_데일리_루틴과_멤버_인형을_생성한다() {
+        // given
+        long memberId = 1L;
+        Member member = member(memberId);
+        DollType dollType = BROWN;
+        String name = "memberDoll";
+        List<Long> routines = List.of(2L, 3L, 4L);
+        MemberProfileRequest request = new MemberProfileRequest(dollType, name, routines);
+        doNothing().when(memberDailyRoutineService).createMemberDailyRoutines(member, List.of(2L, 3L, 4L));
+        doNothing().when(memberDollService).createMemberDoll(member, dollType, name);
+
+        // when
+        memberService.createMemberProfile(memberId, request);
+
+        // then
+        verify(memberDailyRoutineService).createMemberDailyRoutines(member, routines);
+        verify(memberDollService).createMemberDoll(member, dollType, name);
+    }
 
     @Test
     @DisplayName("솜뭉치 개수가 양수일 때 솜뭉치를 줄 수 있다.")
@@ -58,6 +90,12 @@ class MemberServiceImplTest {
         assertThatThrownBy(() -> memberService.giveCotton(member.getId(), CottonType.DAILY))
                 .isInstanceOf(MemberException.class)
                 .hasMessage("[MemberException] : " + NOT_ENOUGH_COTTON.getMessage());
+    }
+
+    private Member member(long memberId) {
+        Member member = MemberFixture.member().id(memberId).build();
+        doReturn(Optional.of(member)).when(memberRepository).findById(1L);
+        return member;
     }
 
     private Member member(long memberId, MemberDoll memberDoll) {

--- a/src/test/java/com/soptie/server/support/ConversationFixture.java
+++ b/src/test/java/com/soptie/server/support/ConversationFixture.java
@@ -1,0 +1,30 @@
+package com.soptie.server.support;
+
+import com.soptie.server.conversation.entity.Conversation;
+
+public class ConversationFixture {
+
+    private Long id;
+    private String content;
+
+    private ConversationFixture() {
+    }
+
+    public static ConversationFixture conversation() {
+        return new ConversationFixture();
+    }
+
+    public ConversationFixture id(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public ConversationFixture content(String content) {
+        this.content = content;
+        return this;
+    }
+
+    public Conversation build() {
+        return new Conversation(id, content);
+    }
+}

--- a/src/test/java/com/soptie/server/support/DollFixture.java
+++ b/src/test/java/com/soptie/server/support/DollFixture.java
@@ -1,10 +1,12 @@
 package com.soptie.server.support;
 
 import com.soptie.server.doll.entity.Doll;
+import com.soptie.server.doll.entity.DollType;
 
 public class DollFixture {
 
     private Long id;
+    private DollType dollType;
     private String faceImageUrl;
 
     private DollFixture() {
@@ -19,12 +21,17 @@ public class DollFixture {
         return this;
     }
 
+    public DollFixture dollType(DollType dollType) {
+        this.dollType = dollType;
+        return this;
+    }
+
     public DollFixture faceImageUrl(String faceImageUrl) {
         this.faceImageUrl = faceImageUrl;
         return this;
     }
 
     public Doll build() {
-        return new Doll(id, faceImageUrl);
+        return new Doll(id, dollType, faceImageUrl);
     }
 }

--- a/src/test/java/com/soptie/server/support/MemberDollFixture.java
+++ b/src/test/java/com/soptie/server/support/MemberDollFixture.java
@@ -1,0 +1,43 @@
+package com.soptie.server.support;
+
+import com.soptie.server.doll.entity.Doll;
+import com.soptie.server.memberDoll.entity.MemberDoll;
+
+public class MemberDollFixture {
+
+    private Long id;
+    private String name;
+    private int happinessCottonCount;
+    private Doll doll;
+
+    public MemberDollFixture() {
+    }
+
+    public static MemberDollFixture memberDoll() {
+        return new MemberDollFixture();
+    }
+
+    public MemberDollFixture id(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public MemberDollFixture name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public MemberDollFixture happinessCottonCount(int happinessCottonCount) {
+        this.happinessCottonCount = happinessCottonCount;
+        return this;
+    }
+
+    public MemberDollFixture doll(Doll doll) {
+        this.doll = doll;
+        return this;
+    }
+
+    public MemberDoll build() {
+        return new MemberDoll(id, name, happinessCottonCount, doll);
+    }
+}


### PR DESCRIPTION
## ✨ Related Issue
- close #210 
  <br/>

## 📝 기능 구현 명세
![image](https://github.com/Team-Sopetit/Sopetit-server/assets/81404890/02de942c-b76b-4111-9193-94ed30497c35)
- MemberService 테스트 결과

## 🐥 추가적인 언급 사항
- deleteMember()는 단순히 jpa repository에서 delete 메소드 호출하는 거라 생략했습니다.
- getMemberHomeInfo()에서 불러올 정보가 많아 코드가 꽤 복잡해진 거 같은데 조금 더 좋은 방안이 떠오르신다면 공유해주시면 감사하겠습니다.