### PR TITLE
[ADD] 데일리 루틴 Swagger 정보 추가

### DIFF
--- a/src/main/java/com/soptie/server/routine/controller/daily/DailyRoutineApi.java
+++ b/src/main/java/com/soptie/server/routine/controller/daily/DailyRoutineApi.java
@@ -15,6 +15,7 @@ import com.soptie.server.routine.dto.DailyThemesResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -24,10 +25,15 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public interface DailyRoutineApi {
 
 	@Operation(
-			summary = "",
-			description = "",
+			summary = "데일리 루틴 테마 목록 조회",
+			description = "데일리 루틴 테마 전체를 이름 오름차순으로 조회한다.",
 			responses = {
 					@ApiResponse(responseCode = "200", description = "성공"),
+					@ApiResponse(
+							responseCode = "4xx",
+							description = "클라이언트(요청) 오류",
+							content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+					),
 					@ApiResponse(
 							responseCode = "500",
 							description = "서버 내부 오류",
@@ -38,10 +44,15 @@ public interface DailyRoutineApi {
 	ResponseEntity<SuccessResponse<DailyThemesResponse>> getThemes();
 
 	@Operation(
-			summary = "",
-			description = "",
+			summary = "테마 목록별 데일리 루틴 목록 조회",
+			description = "테마 목록 중 하나라도 해당되는 데일리 루틴 목록을 이름 오름차순으로 조회한다.",
 			responses = {
 					@ApiResponse(responseCode = "200", description = "성공"),
+					@ApiResponse(
+							responseCode = "4xx",
+							description = "클라이언트(요청) 오류",
+							content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+					),
 					@ApiResponse(
 							responseCode = "500",
 							description = "서버 내부 오류",
@@ -50,14 +61,24 @@ public interface DailyRoutineApi {
 			}
 	)
 	ResponseEntity<SuccessResponse<DailyRoutinesByThemesResponse>> getRoutinesByThemes(
-			@RequestParam List<Long> themes
+			@Parameter(
+					name = "themes",
+					description = "조회할 데일리 루틴 테마 id 목록",
+					in = ParameterIn.QUERY,
+					example = "1,2,3"
+			) @RequestParam List<Long> themes
 	);
 
 	@Operation(
-			summary = "",
-			description = "",
+			summary = "테마별 데일리 루틴 목록 조회",
+			description = "테마에 해당되는 데일리 루틴 목록을 이름 오름차순으로 조회한다.",
 			responses = {
 					@ApiResponse(responseCode = "200", description = "성공"),
+					@ApiResponse(
+							responseCode = "4xx",
+							description = "클라이언트(요청) 오류",
+							content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+					),
 					@ApiResponse(
 							responseCode = "500",
 							description = "서버 내부 오류",
@@ -67,6 +88,11 @@ public interface DailyRoutineApi {
 	)
 	ResponseEntity<SuccessResponse<DailyRoutinesByThemeResponse>> getRoutinesByTheme(
 			@Parameter(hidden = true) Principal principal,
-			@PathVariable long themeId
+			@Parameter(
+					name = "themeId",
+					description = "조회할 데일리 루틴 테마 id",
+					in = ParameterIn.PATH,
+					example = "1"
+			) @PathVariable long themeId
 	);
 }


### PR DESCRIPTION
## ✨ Related Issue
- #117 
  <br/>

## 📝 기능 구현 명세
![image](https://github.com/Team-Sopetit/Sopetit-server/assets/55437339/45296257-cc47-44de-85f7-e2ce59060638)


## 🐥 추가적인 언급 사항
- 데일리 루틴 관련 API 스웨거 정보(어노테이션) 추가했습니다.