### PR TITLE
[REFACTOR] DB 테이블 재구성

### DIFF
--- a/src/main/java/com/soptie/server/expert/entity/Expert.java
+++ b/src/main/java/com/soptie/server/expert/entity/Expert.java
@@ -1,0 +1,32 @@
+package com.soptie.server.expert.entity;
+
+import static jakarta.persistence.GenerationType.*;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Expert {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	@Column(name = "expert_id")
+	private Long id;
+
+	@NotNull
+	private String name;
+
+	private String job;
+
+	private String profileImageUrl;
+
+	@Column(columnDefinition = "TEXT")
+	private String description;
+}

--- a/src/main/java/com/soptie/server/memberRoutine/entity/MemberRoutine.java
+++ b/src/main/java/com/soptie/server/memberRoutine/entity/MemberRoutine.java
@@ -1,0 +1,42 @@
+package com.soptie.server.memberRoutine.entity;
+
+import static jakarta.persistence.EnumType.*;
+import static jakarta.persistence.FetchType.*;
+import static jakarta.persistence.GenerationType.*;
+
+import com.soptie.server.member.entity.Member;
+import com.soptie.server.routine.entity.RoutineType;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class MemberRoutine {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	@Column(name = "member_routine_id")
+	private Long id;
+
+	private boolean isAchieve;
+
+	private int achieveCount;
+
+	@Enumerated(value = STRING)
+	private RoutineType type;
+
+	private long routineId;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+}

--- a/src/main/java/com/soptie/server/routine/entity/Routine.java
+++ b/src/main/java/com/soptie/server/routine/entity/Routine.java
@@ -1,0 +1,39 @@
+package com.soptie.server.routine.entity;
+
+import static jakarta.persistence.EnumType.*;
+import static jakarta.persistence.FetchType.*;
+import static jakarta.persistence.GenerationType.*;
+
+import com.soptie.server.theme.entity.Theme;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Routine {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	@Column(name = "routine_id")
+	private Long id;
+
+	@NotNull
+	private String content;
+
+	@Enumerated(value = STRING)
+	private RoutineType type;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "theme_id")
+	private Theme theme;
+}

--- a/src/main/java/com/soptie/server/routine/entity/RoutineType.java
+++ b/src/main/java/com/soptie/server/routine/entity/RoutineType.java
@@ -1,0 +1,17 @@
+package com.soptie.server.routine.entity;
+
+import static lombok.AccessLevel.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = PROTECTED)
+public enum RoutineType {
+
+	DAILY("데일리"),
+	CHALLENGE("도전"),
+	;
+
+	private final String name;
+}

--- a/src/main/java/com/soptie/server/routine/entity/challenge/Challenge.java
+++ b/src/main/java/com/soptie/server/routine/entity/challenge/Challenge.java
@@ -25,7 +25,6 @@ public class Challenge {
 	@Column(name = "challenge_id")
 	private Long id;
 
-	@NotNull
 	private String content;
 
 	private String description;

--- a/src/main/java/com/soptie/server/routine/entity/challenge/Challenge.java
+++ b/src/main/java/com/soptie/server/routine/entity/challenge/Challenge.java
@@ -1,0 +1,40 @@
+package com.soptie.server.routine.entity.challenge;
+
+import static jakarta.persistence.FetchType.*;
+import static jakarta.persistence.GenerationType.*;
+
+import com.soptie.server.routine.entity.Routine;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Challenge {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	@Column(name = "routine_id")
+	private Long id;
+
+	@NotNull
+	private String content;
+
+	private String description;
+
+	private String requiredTime;
+
+	private String place;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "routine_id")
+	private Routine routine;
+}

--- a/src/main/java/com/soptie/server/routine/entity/challenge/Challenge.java
+++ b/src/main/java/com/soptie/server/routine/entity/challenge/Challenge.java
@@ -22,7 +22,7 @@ public class Challenge {
 
 	@Id
 	@GeneratedValue(strategy = IDENTITY)
-	@Column(name = "routine_id")
+	@Column(name = "challenge_id")
 	private Long id;
 
 	@NotNull

--- a/src/main/java/com/soptie/server/theme/entity/ImageInfo.java
+++ b/src/main/java/com/soptie/server/theme/entity/ImageInfo.java
@@ -1,0 +1,15 @@
+package com.soptie.server.theme.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor
+@Getter
+public class ImageInfo {
+
+	private String iconImageUrl;
+
+	private String backgroundImageUrl;
+}

--- a/src/main/java/com/soptie/server/theme/entity/Theme.java
+++ b/src/main/java/com/soptie/server/theme/entity/Theme.java
@@ -1,0 +1,43 @@
+package com.soptie.server.theme.entity;
+
+import static jakarta.persistence.FetchType.*;
+import static jakarta.persistence.GenerationType.*;
+
+import com.soptie.server.expert.entity.Expert;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Theme {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	@Column(name = "theme_id")
+	private Long id;
+
+	@NotNull
+	private String name;
+
+	@Embedded
+	private ImageInfo imageInfo;
+
+	private String color;
+
+	@Column(columnDefinition = "TEXT")
+	private String description;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "expert_id")
+	private Expert expert;
+}

--- a/src/main/java/com/soptie/server/theme/entity/Theme.java
+++ b/src/main/java/com/soptie/server/theme/entity/Theme.java
@@ -26,7 +26,6 @@ public class Theme {
 	@Column(name = "theme_id")
 	private Long id;
 
-	@NotNull
 	private String name;
 
 	@Embedded


### PR DESCRIPTION
## ✨ Related Issue
- close #225 
  <br/>

## 📝 기능 구현 명세
- [회의록](https://www.notion.so/2cfc12ed13494845b95e0ecca3e3429d?pvs=4)

## 🐥 추가적인 언급 사항
- 전문가, 테마, 루틴, 도전 루틴 상세, 회원의 루틴 테이블을 2차 스프린트에 맞춰 추가했습니다.
- 삭제된 회원의 루틴 테이블은 변동성이 있을 점을 고려하여, 관련 비즈니스 로직을 구현하면서 추가하는 것이 좋을 것 같아 우선 보류했습니다.
- 추가 의견 있으면 리뷰 부탁드려요 :)