### PR TITLE
[FIX] 루틴 달성 및 취소 기능 수정

### DIFF
--- a/src/main/java/com/soptie/server/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/soptie/server/auth/service/AuthServiceImpl.java
@@ -8,6 +8,7 @@ import com.soptie.server.auth.jwt.JwtTokenProvider;
 import com.soptie.server.auth.jwt.UserAuthentication;
 import com.soptie.server.auth.vo.Token;
 import com.soptie.server.common.config.ValueConfig;
+import com.soptie.server.history.achievement.adapter.HistoryAchievedDeleter;
 import com.soptie.server.member.entity.Member;
 import com.soptie.server.member.entity.SocialType;
 import com.soptie.server.member.exception.MemberException;
@@ -41,6 +42,7 @@ public class AuthServiceImpl implements AuthService {
     private final ValueConfig valueConfig;
 
     private final MemberRoutineDeleter memberRoutineDeleter;
+    private final HistoryAchievedDeleter achievedDeleter;
 
     @Override
     @Transactional
@@ -70,6 +72,7 @@ public class AuthServiceImpl implements AuthService {
     public void withdraw(long memberId) {
         val member = findMember(memberId);
         deleteMemberDoll(member.getMemberDoll());
+        achievedDeleter.deleteByMember(member);
         memberRoutineDeleter.deleteByMember(member);
         deleteMember(member);
     }

--- a/src/main/java/com/soptie/server/history/achievement/adapter/HistoryAchievedDeleter.java
+++ b/src/main/java/com/soptie/server/history/achievement/adapter/HistoryAchievedDeleter.java
@@ -1,0 +1,18 @@
+package com.soptie.server.history.achievement.adapter;
+
+import com.soptie.server.common.support.RepositoryAdapter;
+import com.soptie.server.history.achievement.repository.HistoryAchievedRepository;
+import com.soptie.server.member.entity.Member;
+
+import lombok.RequiredArgsConstructor;
+
+@RepositoryAdapter
+@RequiredArgsConstructor
+public class HistoryAchievedDeleter {
+
+	private final HistoryAchievedRepository achievedRepository;
+
+	public void deleteByMember(Member member) {
+		achievedRepository.deleteByMember(member);
+	}
+}

--- a/src/main/java/com/soptie/server/history/achievement/adapter/HistoryAchievedFinder.java
+++ b/src/main/java/com/soptie/server/history/achievement/adapter/HistoryAchievedFinder.java
@@ -1,0 +1,18 @@
+package com.soptie.server.history.achievement.adapter;
+
+import com.soptie.server.common.support.RepositoryAdapter;
+import com.soptie.server.history.achievement.repository.HistoryAchievedRepository;
+import com.soptie.server.memberRoutine.entity.MemberRoutine;
+
+import lombok.RequiredArgsConstructor;
+
+@RepositoryAdapter
+@RequiredArgsConstructor
+public class HistoryAchievedFinder {
+
+	private final HistoryAchievedRepository achievedRepository;
+
+	public boolean isAchievedToday(MemberRoutine routine) {
+		return achievedRepository.isAchievedToday(routine);
+	}
+}

--- a/src/main/java/com/soptie/server/history/achievement/adapter/HistoryAchievedSaver.java
+++ b/src/main/java/com/soptie/server/history/achievement/adapter/HistoryAchievedSaver.java
@@ -1,0 +1,18 @@
+package com.soptie.server.history.achievement.adapter;
+
+import com.soptie.server.common.support.RepositoryAdapter;
+import com.soptie.server.history.achievement.entity.HistoryAchieved;
+import com.soptie.server.history.achievement.repository.HistoryAchievedRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RepositoryAdapter
+@RequiredArgsConstructor
+public class HistoryAchievedSaver {
+
+	private final HistoryAchievedRepository achievedRepository;
+
+	public void save(HistoryAchieved achieved) {
+		achievedRepository.save(achieved);
+	}
+}

--- a/src/main/java/com/soptie/server/history/achievement/entity/AchieveType.java
+++ b/src/main/java/com/soptie/server/history/achievement/entity/AchieveType.java
@@ -1,0 +1,14 @@
+package com.soptie.server.history.achievement.entity;
+
+import com.soptie.server.memberRoutine.entity.MemberRoutine;
+
+public enum AchieveType {
+	ACHIEVE,
+	CANCEL,
+
+	;
+
+	public static AchieveType getType(MemberRoutine memberRoutine) {
+		return memberRoutine.isAchieve() ? ACHIEVE : CANCEL;
+	}
+}

--- a/src/main/java/com/soptie/server/history/achievement/entity/HistoryAchieved.java
+++ b/src/main/java/com/soptie/server/history/achievement/entity/HistoryAchieved.java
@@ -1,0 +1,38 @@
+package com.soptie.server.history.achievement.entity;
+
+import java.time.LocalDateTime;
+
+import com.soptie.server.memberRoutine.entity.MemberRoutine;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+public class HistoryAchieved {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(nullable = false)
+	private Long id;
+
+	private LocalDateTime achievedAt;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "routine_id")
+	private MemberRoutine achievedRoutine;
+
+	public HistoryAchieved(MemberRoutine routine) {
+		this.achievedRoutine = routine;
+		this.achievedAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/soptie/server/history/achievement/entity/HistoryAchieved.java
+++ b/src/main/java/com/soptie/server/history/achievement/entity/HistoryAchieved.java
@@ -1,11 +1,16 @@
 package com.soptie.server.history.achievement.entity;
 
+import static jakarta.persistence.EnumType.*;
+
 import java.time.LocalDateTime;
 
+import com.soptie.server.member.entity.Member;
 import com.soptie.server.memberRoutine.entity.MemberRoutine;
+import com.soptie.server.routine.entity.RoutineType;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -27,12 +32,23 @@ public class HistoryAchieved {
 
 	private LocalDateTime achievedAt;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "routine_id")
-	private MemberRoutine achievedRoutine;
+	@Enumerated(value = STRING)
+	private AchieveType achieveType;
 
-	public HistoryAchieved(MemberRoutine routine) {
-		this.achievedRoutine = routine;
+	@Enumerated(value = STRING)
+	private RoutineType routineType;
+
+	private long routineId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	public HistoryAchieved(MemberRoutine memberRoutine) {
 		this.achievedAt = LocalDateTime.now();
+		this.achieveType = AchieveType.getType(memberRoutine);
+		this.routineType = memberRoutine.getType();
+		this.routineId = memberRoutine.getRoutineId();
+		this.member = memberRoutine.getMember();
 	}
 }

--- a/src/main/java/com/soptie/server/history/achievement/repository/HistoryAchievedCustomRepository.java
+++ b/src/main/java/com/soptie/server/history/achievement/repository/HistoryAchievedCustomRepository.java
@@ -1,0 +1,8 @@
+package com.soptie.server.history.achievement.repository;
+
+import com.soptie.server.memberRoutine.entity.MemberRoutine;
+
+public interface HistoryAchievedCustomRepository {
+
+	boolean isAchievedToday(MemberRoutine routine);
+}

--- a/src/main/java/com/soptie/server/history/achievement/repository/HistoryAchievedRepository.java
+++ b/src/main/java/com/soptie/server/history/achievement/repository/HistoryAchievedRepository.java
@@ -3,6 +3,8 @@ package com.soptie.server.history.achievement.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.soptie.server.history.achievement.entity.HistoryAchieved;
+import com.soptie.server.member.entity.Member;
 
 public interface HistoryAchievedRepository extends JpaRepository<HistoryAchieved, Long>, HistoryAchievedCustomRepository {
+	void deleteByMember(Member member);
 }

--- a/src/main/java/com/soptie/server/history/achievement/repository/HistoryAchievedRepository.java
+++ b/src/main/java/com/soptie/server/history/achievement/repository/HistoryAchievedRepository.java
@@ -1,0 +1,8 @@
+package com.soptie.server.history.achievement.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.soptie.server.history.achievement.entity.HistoryAchieved;
+
+public interface HistoryAchievedRepository extends JpaRepository<HistoryAchieved, Long>, HistoryAchievedCustomRepository {
+}

--- a/src/main/java/com/soptie/server/history/achievement/repository/HistoryAchievedRepositoryImpl.java
+++ b/src/main/java/com/soptie/server/history/achievement/repository/HistoryAchievedRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.soptie.server.history.achievement.repository;
+
+import static com.soptie.server.history.achievement.entity.QHistoryAchieved.*;
+
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.soptie.server.history.achievement.entity.AchieveType;
+import com.soptie.server.memberRoutine.entity.MemberRoutine;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+@Repository
+@RequiredArgsConstructor
+public class HistoryAchievedRepositoryImpl implements HistoryAchievedCustomRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public boolean isAchievedToday(MemberRoutine memberRoutine) {
+		val today = LocalDate.now().atStartOfDay();
+		return queryFactory
+				.from(historyAchieved)
+				.where(
+						historyAchieved.achievedAt.between(today, today.plusDays(1)),
+						historyAchieved.member.eq(memberRoutine.getMember()),
+						historyAchieved.routineId.eq(memberRoutine.getRoutineId()),
+						historyAchieved.routineType.eq(memberRoutine.getType()),
+						historyAchieved.achieveType.eq(AchieveType.ACHIEVE)
+				)
+				.select(historyAchieved.id)
+				.fetchFirst() != null;
+	}
+}

--- a/src/main/java/com/soptie/server/memberRoutine/controller/v1/dto/response/MemberDailyRoutineAchieveResponse.java
+++ b/src/main/java/com/soptie/server/memberRoutine/controller/v1/dto/response/MemberDailyRoutineAchieveResponse.java
@@ -10,7 +10,8 @@ import lombok.Builder;
 public record MemberDailyRoutineAchieveResponse(
 	long routineId,
 	boolean isAchieve,
-	int achieveCount
+	int achieveCount,
+	boolean isAchievedToday
 ) {
 
 	public static MemberDailyRoutineAchieveResponse of(MemberRoutineAchieveServiceResponse response) {
@@ -18,6 +19,7 @@ public record MemberDailyRoutineAchieveResponse(
 				.routineId(response.routineId())
 				.isAchieve(response.isAchieve())
 				.achieveCount(response.achieveCount())
+				.isAchievedToday(response.isAchievedToday())
 				.build();
 	}
 }

--- a/src/main/java/com/soptie/server/memberRoutine/controller/v2/MemberChallengeRoutineApi.java
+++ b/src/main/java/com/soptie/server/memberRoutine/controller/v2/MemberChallengeRoutineApi.java
@@ -1,0 +1,59 @@
+package com.soptie.server.memberRoutine.controller.v2;
+
+import java.security.Principal;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.soptie.server.common.dto.BaseResponse;
+import com.soptie.server.common.dto.ErrorResponse;
+import com.soptie.server.common.dto.SuccessResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "member challenge routines V2", description = "회원의 도전 루틴 API Version2")
+public interface MemberChallengeRoutineApi {
+
+    @Operation(
+            summary = "도전 루틴 달성",
+            description = "회원의 도전 루틴을 달성한다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "성공",
+                            content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = "유효하지 않은 토큰",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "4xx",
+                            description = "클라이언트(요청) 오류",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "서버 내부 오류",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    )
+            }
+    )
+    ResponseEntity<BaseResponse> achieve(
+            @Parameter(hidden = true) Principal principal,
+            @Parameter(
+                    name = "routineId",
+                    description = "달성한 회원의 도전 루틴 id",
+                    in = ParameterIn.PATH,
+                    example = "1"
+            )
+            @PathVariable Long routineId
+    );
+}

--- a/src/main/java/com/soptie/server/memberRoutine/controller/v2/MemberChallengeRoutineController.java
+++ b/src/main/java/com/soptie/server/memberRoutine/controller/v2/MemberChallengeRoutineController.java
@@ -1,0 +1,42 @@
+package com.soptie.server.memberRoutine.controller.v2;
+
+import static com.soptie.server.common.dto.SuccessResponse.*;
+import static com.soptie.server.memberRoutine.message.SuccessMessage.*;
+
+import java.security.Principal;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.soptie.server.common.dto.BaseResponse;
+import com.soptie.server.memberRoutine.controller.v2.dto.response.MemberChallengeRoutineAchieveResponse;
+import com.soptie.server.memberRoutine.service.MemberRoutineUpdateService;
+import com.soptie.server.memberRoutine.service.dto.request.MemberRoutineAchieveServiceRequest;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/routines/challenge/member")
+public class MemberChallengeRoutineController implements MemberChallengeRoutineApi {
+
+    private final MemberRoutineUpdateService memberRoutineUpdateService;
+
+    @PatchMapping("/routine/{routineId}")
+    public ResponseEntity<BaseResponse> achieve(
+            Principal principal,
+            @PathVariable Long routineId
+    ) {
+        val memberId = Long.parseLong(principal.getName());
+        val response = memberRoutineUpdateService.achieveMemberRoutine(
+                MemberRoutineAchieveServiceRequest.of(memberId, routineId));
+        return ResponseEntity.ok(success(
+                SUCCESS_ACHIEVE_ROUTINE.getMessage(),
+                MemberChallengeRoutineAchieveResponse.of(response)
+        ));
+    }
+}

--- a/src/main/java/com/soptie/server/memberRoutine/controller/v2/dto/response/MemberChallengeRoutineAchieveResponse.java
+++ b/src/main/java/com/soptie/server/memberRoutine/controller/v2/dto/response/MemberChallengeRoutineAchieveResponse.java
@@ -1,0 +1,25 @@
+package com.soptie.server.memberRoutine.controller.v2.dto.response;
+
+import static lombok.AccessLevel.*;
+
+import com.soptie.server.memberRoutine.service.dto.response.MemberRoutineAchieveServiceResponse;
+
+import lombok.Builder;
+
+@Builder(access = PRIVATE)
+public record MemberChallengeRoutineAchieveResponse(
+	long routineId,
+	boolean isAchieve,
+	int achieveCount,
+	boolean isAchievedToday
+) {
+
+	public static MemberChallengeRoutineAchieveResponse of(MemberRoutineAchieveServiceResponse response) {
+		return MemberChallengeRoutineAchieveResponse.builder()
+				.routineId(response.routineId())
+				.isAchieve(response.isAchieve())
+				.achieveCount(response.achieveCount())
+				.isAchievedToday(response.isAchievedToday())
+				.build();
+	}
+}

--- a/src/main/java/com/soptie/server/memberRoutine/entity/MemberRoutine.java
+++ b/src/main/java/com/soptie/server/memberRoutine/entity/MemberRoutine.java
@@ -85,11 +85,15 @@ public class MemberRoutine {
 
 	public void achieve() {
 		this.isAchieve = true;
-		this.achieveCount++;
+	}
+
+	public void cancel() {
+		this.isAchieve = false;
 	}
 
 	public void initAchieve() {
 		this.isAchieve = false;
+		this.achieveCount++;
 	}
 
 	public void checkMemberHas(Member member) {

--- a/src/main/java/com/soptie/server/memberRoutine/service/dto/response/MemberRoutineAchieveServiceResponse.java
+++ b/src/main/java/com/soptie/server/memberRoutine/service/dto/response/MemberRoutineAchieveServiceResponse.java
@@ -10,14 +10,16 @@ import lombok.Builder;
 public record MemberRoutineAchieveServiceResponse(
 		long routineId,
 		boolean isAchieve,
-		int achieveCount
+		int achieveCount,
+		boolean isAchievedToday
 ) {
 
-	public static MemberRoutineAchieveServiceResponse of(MemberRoutine routine) {
+	public static MemberRoutineAchieveServiceResponse of(MemberRoutine routine, boolean isAchievedToday) {
 		return MemberRoutineAchieveServiceResponse.builder()
 				.routineId(routine.getId())
 				.isAchieve(routine.isAchieve())
 				.achieveCount(routine.getAchieveCount())
+				.isAchievedToday(isAchievedToday)
 				.build();
 	}
 }

--- a/src/test/java/com/soptie/server/memberRoutine/service/MemberRoutineServiceTest.java
+++ b/src/test/java/com/soptie/server/memberRoutine/service/MemberRoutineServiceTest.java
@@ -15,6 +15,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.soptie.server.history.achievement.adapter.HistoryAchievedFinder;
+import com.soptie.server.history.achievement.adapter.HistoryAchievedSaver;
 import com.soptie.server.member.adapter.MemberFinder;
 import com.soptie.server.member.entity.Member;
 import com.soptie.server.memberRoutine.adapter.MemberRoutineDeleter;
@@ -40,19 +42,23 @@ class MemberRoutineServiceTest {
 	@Mock
 	private MemberRoutineDeleter memberRoutineDeleter;
 
+	@Mock
+	private HistoryAchievedSaver achievedSaver;
+
+	@Mock
+	private HistoryAchievedFinder achievedFinder;
+
 	@Test
 	@DisplayName("[성공] 데일리 루틴을 달성하면 달성 횟수와 데일리 솜 뭉치 개수가 1만큼 증가한다.")
 	void shouldUpdateAchieveCountAndCottonCountWhenAchieveDailyRoutine() {
 		// given
 		int beforeCottonCount = 0;
-		int beforeAchieveCount = 0;
 
 		Member member = MemberFixture.member().id(1L).dailyCotton(beforeCottonCount).build();
 		MemberRoutine memberRoutine = MemberRoutineFixture.memberRoutine()
 				.id(3L)
 				.type(DAILY)
 				.isAchieve(false)
-				.achieveCount(beforeAchieveCount)
 				.member(member)
 				.build();
 
@@ -69,7 +75,6 @@ class MemberRoutineServiceTest {
 
 		// then
 		assertThat(memberRoutine.isAchieve()).isTrue();
-		assertThat(memberRoutine.getAchieveCount()).isEqualTo(beforeAchieveCount + 1);
 		assertThat(member.getCottonInfo().getDailyCottonCount()).isEqualTo(beforeCottonCount + 1);
 	}
 
@@ -78,14 +83,12 @@ class MemberRoutineServiceTest {
 	void shouldUpdateAchieveCountAndCottonCountWhenAchieveHappinessRoutine() {
 		// given
 		int beforeCottonCount = 0;
-		int beforeAchieveCount = 0;
 
 		Member member = MemberFixture.member().id(1L).dailyCotton(beforeCottonCount).build();
 		MemberRoutine memberRoutine = MemberRoutineFixture.memberRoutine()
 				.id(3L)
 				.type(CHALLENGE)
 				.isAchieve(false)
-				.achieveCount(beforeAchieveCount)
 				.member(member)
 				.build();
 
@@ -103,7 +106,6 @@ class MemberRoutineServiceTest {
 
 		// then
 		assertThat(memberRoutine.isAchieve()).isTrue();
-		assertThat(memberRoutine.getAchieveCount()).isEqualTo(beforeAchieveCount + 1);
 		assertThat(member.getCottonInfo().getHappinessCottonCount()).isEqualTo(beforeCottonCount + 1);
 	}
 


### PR DESCRIPTION
## ✨ Related Issue
- close #274
  <br/>

## 📝 기능 구현 명세
- 테스트 코드 대체

## 🐥 추가적인 언급 사항
- 달성된 루틴에 대한 요청 시 달성 취소 처리됩니다.
- 달성되지 않은 루틴에 대한 요청 시 달성 처리됩니다.
- 도전 루틴 달성 api 추가했습니다. (데일리 루틴 달성 로직과 같은 기능)