### PR TITLE
[FEAT] 테마별 데일리 루틴 목록 조회(public, 온보딩) 기능 구현

### DIFF
--- a/src/main/java/com/soptie/server/common/config/SecurityConfig.java
+++ b/src/main/java/com/soptie/server/common/config/SecurityConfig.java
@@ -67,6 +67,7 @@ public class SecurityConfig {
 				.requestMatchers(new AntPathRequestMatcher("/api/v1/routines/daily")).permitAll()
 				.requestMatchers(new AntPathRequestMatcher("/api/v1/dolls/image/{type}")).permitAll()
 				.requestMatchers(new AntPathRequestMatcher("/api/v1/versions/client/app")).permitAll()
+				.requestMatchers(new AntPathRequestMatcher("/api/v2/routines/daily", "GET")).permitAll()
 				.requestMatchers(new AntPathRequestMatcher("/error")).permitAll()
 				.anyRequest().authenticated()
 		);

--- a/src/main/java/com/soptie/server/routine/adapter/RoutineFinder.java
+++ b/src/main/java/com/soptie/server/routine/adapter/RoutineFinder.java
@@ -8,8 +8,10 @@ import java.util.List;
 import com.soptie.server.common.support.RepositoryAdapter;
 import com.soptie.server.member.entity.Member;
 import com.soptie.server.routine.entity.Routine;
+import com.soptie.server.routine.entity.RoutineType;
 import com.soptie.server.routine.exception.RoutineException;
 import com.soptie.server.routine.repository.RoutineRepository;
+import com.soptie.server.routine.service.vo.RoutineVO;
 import com.soptie.server.theme.entity.Theme;
 
 import lombok.RequiredArgsConstructor;
@@ -30,10 +32,14 @@ public class RoutineFinder {
 
 	public Routine findById(long id) {
 		return routineRepository.findById(id)
-				.orElseThrow(() -> new RoutineException(INVALID_ROUTINE));
+			.orElseThrow(() -> new RoutineException(INVALID_ROUTINE));
 	}
 
 	public List<Routine> findChallengeRoutinesByTheme(Long themeId) {
 		return routineRepository.findByTypeAndThemeId(CHALLENGE, themeId);
+	}
+
+	public List<RoutineVO> findAllByTypeAndThemeId(RoutineType type, long themeId) {
+		return routineRepository.findByTypeAndThemeId(type, themeId).stream().map(RoutineVO::from).toList();
 	}
 }

--- a/src/main/java/com/soptie/server/routine/controller/v2/DailyRoutineControllerV2.java
+++ b/src/main/java/com/soptie/server/routine/controller/v2/DailyRoutineControllerV2.java
@@ -1,8 +1,5 @@
 package com.soptie.server.routine.controller.v2;
 
-import static com.soptie.server.common.dto.SuccessResponse.*;
-import static com.soptie.server.routine.message.RoutineSuccessMessage.*;
-
 import java.util.LinkedHashSet;
 
 import org.springframework.http.ResponseEntity;
@@ -14,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.soptie.server.common.dto.SuccessResponse;
 import com.soptie.server.routine.controller.v2.docs.DailyRoutineControllerV2Docs;
 import com.soptie.server.routine.controller.v2.dto.response.DailyRoutineListAcquireResponseV2;
+import com.soptie.server.routine.message.RoutineSuccessMessage;
 import com.soptie.server.routine.service.RoutineService;
 
 import lombok.RequiredArgsConstructor;
@@ -31,8 +29,8 @@ public class DailyRoutineControllerV2 implements DailyRoutineControllerV2Docs {
 		@RequestParam LinkedHashSet<Long> themeIds
 	) {
 		val response = routineService.acquireAllInDailyWithThemeId(themeIds);
-		return ResponseEntity.ok(success(
-			SUCCESS_GET_ROUTINE.getMessage(),
+		return ResponseEntity.ok(SuccessResponse.success(
+			RoutineSuccessMessage.SUCCESS_GET_ROUTINE.getMessage(),
 			DailyRoutineListAcquireResponseV2.from(response)));
 	}
 }

--- a/src/main/java/com/soptie/server/routine/controller/v2/DailyRoutineControllerV2.java
+++ b/src/main/java/com/soptie/server/routine/controller/v2/DailyRoutineControllerV2.java
@@ -3,7 +3,7 @@ package com.soptie.server.routine.controller.v2;
 import static com.soptie.server.common.dto.SuccessResponse.*;
 import static com.soptie.server.routine.message.RoutineSuccessMessage.*;
 
-import java.util.Set;
+import java.util.LinkedHashSet;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,7 +28,7 @@ public class DailyRoutineControllerV2 implements DailyRoutineControllerV2Docs {
 
 	@GetMapping
 	public ResponseEntity<SuccessResponse<DailyRoutineListAcquireResponseV2>> acquireAllByThemes(
-		@RequestParam Set<Long> themeIds
+		@RequestParam LinkedHashSet<Long> themeIds
 	) {
 		val response = routineService.acquireAllInDailyWithThemeId(themeIds);
 		return ResponseEntity.ok(success(

--- a/src/main/java/com/soptie/server/routine/controller/v2/DailyRoutineControllerV2.java
+++ b/src/main/java/com/soptie/server/routine/controller/v2/DailyRoutineControllerV2.java
@@ -1,0 +1,38 @@
+package com.soptie.server.routine.controller.v2;
+
+import static com.soptie.server.common.dto.SuccessResponse.*;
+import static com.soptie.server.routine.message.RoutineSuccessMessage.*;
+
+import java.util.Set;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.soptie.server.common.dto.SuccessResponse;
+import com.soptie.server.routine.controller.v2.docs.DailyRoutineControllerV2Docs;
+import com.soptie.server.routine.controller.v2.dto.response.DailyRoutineListAcquireResponseV2;
+import com.soptie.server.routine.service.RoutineService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/routines/daily")
+public class DailyRoutineControllerV2 implements DailyRoutineControllerV2Docs {
+
+	private final RoutineService routineService;
+
+	@GetMapping
+	public ResponseEntity<SuccessResponse<DailyRoutineListAcquireResponseV2>> acquireAllByThemes(
+		@RequestParam Set<Long> themeIds
+	) {
+		val response = routineService.acquireAllInDailyWithThemeId(themeIds);
+		return ResponseEntity.ok(success(
+			SUCCESS_GET_ROUTINE.getMessage(),
+			DailyRoutineListAcquireResponseV2.from(response)));
+	}
+}

--- a/src/main/java/com/soptie/server/routine/controller/v2/docs/DailyRoutineControllerV2Docs.java
+++ b/src/main/java/com/soptie/server/routine/controller/v2/docs/DailyRoutineControllerV2Docs.java
@@ -1,6 +1,6 @@
 package com.soptie.server.routine.controller.v2.docs;
 
-import java.util.Set;
+import java.util.LinkedHashSet;
 
 import org.springframework.http.ResponseEntity;
 
@@ -12,6 +12,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 public interface DailyRoutineControllerV2Docs {
 
 	ResponseEntity<SuccessResponse<DailyRoutineListAcquireResponseV2>> acquireAllByThemes(
-		@Parameter(name = "list of themes id", description = "조회할 테마 id 목록") Set<Long> themeIds
+		@Parameter(name = "list of themes id", description = "조회할 테마 id 목록") LinkedHashSet<Long> themeIds
 	);
 }

--- a/src/main/java/com/soptie/server/routine/controller/v2/docs/DailyRoutineControllerV2Docs.java
+++ b/src/main/java/com/soptie/server/routine/controller/v2/docs/DailyRoutineControllerV2Docs.java
@@ -1,0 +1,17 @@
+package com.soptie.server.routine.controller.v2.docs;
+
+import java.util.Set;
+
+import org.springframework.http.ResponseEntity;
+
+import com.soptie.server.common.dto.SuccessResponse;
+import com.soptie.server.routine.controller.v2.dto.response.DailyRoutineListAcquireResponseV2;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+public interface DailyRoutineControllerV2Docs {
+
+	ResponseEntity<SuccessResponse<DailyRoutineListAcquireResponseV2>> acquireAllByThemes(
+		@Parameter(name = "list of themes id", description = "조회할 테마 id 목록") Set<Long> themeIds
+	);
+}

--- a/src/main/java/com/soptie/server/routine/controller/v2/dto/response/DailyRoutineListAcquireResponseV2.java
+++ b/src/main/java/com/soptie/server/routine/controller/v2/dto/response/DailyRoutineListAcquireResponseV2.java
@@ -1,16 +1,15 @@
 package com.soptie.server.routine.controller.v2.dto.response;
 
-import static lombok.AccessLevel.*;
-
 import java.util.List;
 import java.util.Map;
 
 import com.soptie.server.routine.service.vo.RoutineVO;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
 import lombok.Builder;
 
-@Builder(access = PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
 public record DailyRoutineListAcquireResponseV2(
 	List<ThemeResponse> themes
 ) {
@@ -21,7 +20,7 @@ public record DailyRoutineListAcquireResponseV2(
 			.build();
 	}
 
-	@Builder(access = PRIVATE)
+	@Builder(access = AccessLevel.PRIVATE)
 	private record ThemeResponse(
 		long themeId,
 		List<RoutineResponse> routines
@@ -35,7 +34,7 @@ public record DailyRoutineListAcquireResponseV2(
 		}
 	}
 
-	@Builder(access = PRIVATE)
+	@Builder(access = AccessLevel.PRIVATE)
 	private record RoutineResponse(
 		long routineId,
 		@NotNull String content

--- a/src/main/java/com/soptie/server/routine/controller/v2/dto/response/DailyRoutineListAcquireResponseV2.java
+++ b/src/main/java/com/soptie/server/routine/controller/v2/dto/response/DailyRoutineListAcquireResponseV2.java
@@ -1,0 +1,51 @@
+package com.soptie.server.routine.controller.v2.dto.response;
+
+import static lombok.AccessLevel.*;
+
+import java.util.List;
+import java.util.Map;
+
+import com.soptie.server.routine.service.vo.RoutineVO;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder(access = PRIVATE)
+public record DailyRoutineListAcquireResponseV2(
+	List<ThemeResponse> themes
+) {
+
+	public static DailyRoutineListAcquireResponseV2 from(Map<Long, List<RoutineVO>> routinesMap) {
+		return DailyRoutineListAcquireResponseV2.builder()
+			.themes(routinesMap.keySet().stream().map(key -> ThemeResponse.from(key, routinesMap.get(key))).toList())
+			.build();
+	}
+
+	@Builder(access = PRIVATE)
+	private record ThemeResponse(
+		long themeId,
+		List<RoutineResponse> routines
+	) {
+
+		private static ThemeResponse from(long themeId, List<RoutineVO> routines) {
+			return ThemeResponse.builder()
+				.themeId(themeId)
+				.routines(routines.stream().map(RoutineResponse::from).toList())
+				.build();
+		}
+	}
+
+	@Builder(access = PRIVATE)
+	private record RoutineResponse(
+		long routineId,
+		@NotNull String content
+	) {
+
+		private static RoutineResponse from(RoutineVO routine) {
+			return RoutineResponse.builder()
+				.routineId(routine.routineId())
+				.content(routine.content())
+				.build();
+		}
+	}
+}

--- a/src/main/java/com/soptie/server/routine/service/RoutineService.java
+++ b/src/main/java/com/soptie/server/routine/service/RoutineService.java
@@ -64,7 +64,6 @@ public class RoutineService {
 	}
 
 	public Map<Long, List<RoutineVO>> acquireAllInDailyWithThemeId(Set<Long> themeIds) {
-		System.out.println(themeIds);
 		val themeToRoutine = new LinkedHashMap<Long, List<RoutineVO>>();
 		for (val themeId : themeIds) {
 			val routines = routineFinder.findAllByTypeAndThemeId(DAILY, themeId);

--- a/src/main/java/com/soptie/server/routine/service/RoutineService.java
+++ b/src/main/java/com/soptie/server/routine/service/RoutineService.java
@@ -1,5 +1,12 @@
 package com.soptie.server.routine.service;
 
+import static com.soptie.server.routine.entity.RoutineType.*;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +20,7 @@ import com.soptie.server.routine.service.dto.request.HappinessSubRoutineListGetS
 import com.soptie.server.routine.service.dto.response.DailyRoutineListGetServiceResponse;
 import com.soptie.server.routine.service.dto.response.HappinessRoutineListGetServiceResponse;
 import com.soptie.server.routine.service.dto.response.HappinessSubRoutineListGetServiceResponse;
+import com.soptie.server.routine.service.vo.RoutineVO;
 import com.soptie.server.theme.adapter.ThemeFinder;
 
 import lombok.RequiredArgsConstructor;
@@ -53,5 +61,15 @@ public class RoutineService {
 		val routine = routineFinder.findById(request.routineId());
 		val subRoutines = challengeFinder.findByRoutine(routine);
 		return HappinessSubRoutineListGetServiceResponse.of(routine, subRoutines);
+	}
+
+	public Map<Long, List<RoutineVO>> acquireAllInDailyWithThemeId(Set<Long> themeIds) {
+		System.out.println(themeIds);
+		val themeToRoutine = new LinkedHashMap<Long, List<RoutineVO>>();
+		for (val themeId : themeIds) {
+			val routines = routineFinder.findAllByTypeAndThemeId(DAILY, themeId);
+			themeToRoutine.put(themeId, routines);
+		}
+		return themeToRoutine;
 	}
 }

--- a/src/main/java/com/soptie/server/routine/service/RoutineService.java
+++ b/src/main/java/com/soptie/server/routine/service/RoutineService.java
@@ -1,7 +1,5 @@
 package com.soptie.server.routine.service;
 
-import static com.soptie.server.routine.entity.RoutineType.*;
-
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -13,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.soptie.server.member.adapter.MemberFinder;
 import com.soptie.server.routine.adapter.ChallengeFinder;
 import com.soptie.server.routine.adapter.RoutineFinder;
+import com.soptie.server.routine.entity.RoutineType;
 import com.soptie.server.routine.service.dto.request.DailyRoutineListByThemeGetServiceRequest;
 import com.soptie.server.routine.service.dto.request.DailyRoutineListByThemesGetServiceRequest;
 import com.soptie.server.routine.service.dto.request.HappinessRoutineListGetServiceRequest;
@@ -66,7 +65,7 @@ public class RoutineService {
 	public Map<Long, List<RoutineVO>> acquireAllInDailyWithThemeId(Set<Long> themeIds) {
 		val themeToRoutine = new LinkedHashMap<Long, List<RoutineVO>>();
 		for (val themeId : themeIds) {
-			val routines = routineFinder.findAllByTypeAndThemeId(DAILY, themeId);
+			val routines = routineFinder.findAllByTypeAndThemeId(RoutineType.DAILY, themeId);
 			themeToRoutine.put(themeId, routines);
 		}
 		return themeToRoutine;

--- a/src/main/java/com/soptie/server/routine/service/vo/RoutineVO.java
+++ b/src/main/java/com/soptie/server/routine/service/vo/RoutineVO.java
@@ -1,14 +1,13 @@
 package com.soptie.server.routine.service.vo;
 
-import static lombok.AccessLevel.*;
-
 import com.soptie.server.routine.entity.Routine;
 import com.soptie.server.routine.entity.RoutineType;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
 import lombok.Builder;
 
-@Builder(access = PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
 public record RoutineVO(
 	long routineId,
 	@NotNull String content,

--- a/src/main/java/com/soptie/server/routine/service/vo/RoutineVO.java
+++ b/src/main/java/com/soptie/server/routine/service/vo/RoutineVO.java
@@ -1,0 +1,25 @@
+package com.soptie.server.routine.service.vo;
+
+import static lombok.AccessLevel.*;
+
+import com.soptie.server.routine.entity.Routine;
+import com.soptie.server.routine.entity.RoutineType;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder(access = PRIVATE)
+public record RoutineVO(
+	long routineId,
+	@NotNull String content,
+	@NotNull RoutineType routineType
+) {
+
+	public static RoutineVO from(Routine routine) {
+		return RoutineVO.builder()
+			.routineId(routine.getId())
+			.content(routine.getContent())
+			.routineType(routine.getType())
+			.build();
+	}
+}

--- a/src/test/java/com/soptie/server/routine/service/integration/RoutineServiceIntegrationTest.java
+++ b/src/test/java/com/soptie/server/routine/service/integration/RoutineServiceIntegrationTest.java
@@ -1,13 +1,11 @@
 package com.soptie.server.routine.service.integration;
 
-import static com.soptie.server.routine.entity.RoutineType.*;
-import static org.assertj.core.api.Assertions.*;
-
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -20,6 +18,7 @@ import com.soptie.server.member.repository.MemberRepository;
 import com.soptie.server.memberroutine.repository.MemberRoutineRepository;
 import com.soptie.server.routine.entity.Challenge;
 import com.soptie.server.routine.entity.Routine;
+import com.soptie.server.routine.entity.RoutineType;
 import com.soptie.server.routine.repository.ChallengeRepository;
 import com.soptie.server.routine.repository.RoutineRepository;
 import com.soptie.server.routine.service.RoutineService;
@@ -86,11 +85,11 @@ public class RoutineServiceIntegrationTest {
 				theme3 = themeRepository.save(ThemeFixture.theme().name("새로운 나").build());
 
 				routineOfTheme1 = routineRepository.save(
-					RoutineFixture.routine().type(DAILY).content("관계를 쌓아보자").theme(theme1).build());
+					RoutineFixture.routine().type(RoutineType.DAILY).content("관계를 쌓아보자").theme(theme1).build());
 				routineOfTheme2 = routineRepository.save(
-					RoutineFixture.routine().type(DAILY).content("성장하자").theme(theme2).build());
+					RoutineFixture.routine().type(RoutineType.DAILY).content("성장하자").theme(theme2).build());
 				routineOfTheme3 = routineRepository.save(
-					RoutineFixture.routine().type(DAILY).content("보여줄게 완전히 달라진 나").theme(theme3).build());
+					RoutineFixture.routine().type(RoutineType.DAILY).content("완전히 달라진 나").theme(theme3).build());
 			}
 
 			@Test
@@ -105,13 +104,14 @@ public class RoutineServiceIntegrationTest {
 				final DailyRoutineListGetServiceResponse actual = routineService.getRoutinesByThemes(request);
 
 				// then
-				assertThat(actual.routines()).hasSize(2);
+				Assertions.assertThat(actual.routines()).hasSize(2);
 				List<Long> routineIds = actual.routines().stream().map(DailyRoutineServiceResponse::routineId).toList();
-				assertThat(routineIds).containsExactlyInAnyOrder(routineOfTheme1.getId(), routineOfTheme2.getId());
+				Assertions.assertThat(routineIds)
+					.containsExactlyInAnyOrder(routineOfTheme1.getId(), routineOfTheme2.getId());
 			}
 
 			@Test
-			@DisplayName("[성공] 각 테마(id)별로 데일리 루틴 목록을 조회한다.")
+			@DisplayName("[성공] 각 테마 id 별로 데일리 루틴 목록을 조회한다.")
 			void acquireAllWithThemeIds() {
 				// given
 				Set<Long> themeIds = new LinkedHashSet<>();
@@ -122,13 +122,13 @@ public class RoutineServiceIntegrationTest {
 				final Map<Long, List<RoutineVO>> actual = routineService.acquireAllInDailyWithThemeId(themeIds);
 
 				// then
-				assertThat(actual.keySet()).containsExactly(theme2.getId(), theme1.getId());
+				Assertions.assertThat(actual.keySet()).containsExactly(theme2.getId(), theme1.getId());
 
 				List<Long> routineIdsForTheme1 = actual.get(theme1.getId()).stream().map(RoutineVO::routineId).toList();
-				assertThat(routineIdsForTheme1).containsExactlyInAnyOrder(routineOfTheme1.getId());
+				Assertions.assertThat(routineIdsForTheme1).containsExactlyInAnyOrder(routineOfTheme1.getId());
 
 				List<Long> routineIdsForTheme2 = actual.get(theme2.getId()).stream().map(RoutineVO::routineId).toList();
-				assertThat(routineIdsForTheme2).containsExactlyInAnyOrder(routineOfTheme2.getId());
+				Assertions.assertThat(routineIdsForTheme2).containsExactlyInAnyOrder(routineOfTheme2.getId());
 			}
 		}
 
@@ -151,18 +151,19 @@ public class RoutineServiceIntegrationTest {
 			theme = themeRepository.save(ThemeFixture.theme().name("관계 쌓기").build());
 
 			routine1 = routineRepository.save(
-				RoutineFixture.routine().type(DAILY).content("관계 쌓자").theme(theme).build());
+				RoutineFixture.routine().type(RoutineType.DAILY).content("관계 쌓자").theme(theme).build());
 			routine2 = routineRepository.save(
-				RoutineFixture.routine().type(DAILY).content("쌓자 관계").theme(theme).build());
-			routineNoTheme = routineRepository.save(RoutineFixture.routine().type(DAILY).content("테마 없음").build());
+				RoutineFixture.routine().type(RoutineType.DAILY).content("쌓자 관계").theme(theme).build());
+			routineNoTheme = routineRepository.save(
+				RoutineFixture.routine().type(RoutineType.DAILY).content("테마 없음").build());
 			routineMemberHas = routineRepository.save(
-				RoutineFixture.routine().type(DAILY).content("쌓자 관계").theme(theme).build());
+				RoutineFixture.routine().type(RoutineType.DAILY).content("쌓자 관계").theme(theme).build());
 			challengeRoutine = routineRepository.save(
-				RoutineFixture.routine().type(CHALLENGE).content("관계 도전").theme(theme).build());
+				RoutineFixture.routine().type(RoutineType.CHALLENGE).content("관계 도전").theme(theme).build());
 
 			memberRoutineRepository.save(
 				MemberRoutineFixture.memberRoutine()
-					.type(DAILY)
+					.type(RoutineType.DAILY)
 					.routineId(routineMemberHas.getId())
 					.member(member)
 					.build());
@@ -180,7 +181,7 @@ public class RoutineServiceIntegrationTest {
 
 			// then
 			List<Long> routineIds = actual.routines().stream().map(DailyRoutineServiceResponse::routineId).toList();
-			assertThat(routineIds).containsExactlyInAnyOrder(routine1.getId(), routine2.getId());
+			Assertions.assertThat(routineIds).containsExactlyInAnyOrder(routine1.getId(), routine2.getId());
 		}
 	}
 
@@ -199,11 +200,11 @@ public class RoutineServiceIntegrationTest {
 			theme2 = themeRepository.save(ThemeFixture.theme().name("한 걸음 성장").color("민트").build());
 
 			routine1 = routineRepository.save(
-				RoutineFixture.routine().type(CHALLENGE).content("관계쌓는").theme(theme1).build());
+				RoutineFixture.routine().type(RoutineType.CHALLENGE).content("관계쌓는").theme(theme1).build());
 			routine2 = routineRepository.save(
-				RoutineFixture.routine().type(CHALLENGE).content("성장하는").theme(theme1).build());
+				RoutineFixture.routine().type(RoutineType.CHALLENGE).content("성장하는").theme(theme1).build());
 			routine3 = routineRepository.save(
-				RoutineFixture.routine().type(CHALLENGE).content("보여주는").theme(theme2).build());
+				RoutineFixture.routine().type(RoutineType.CHALLENGE).content("보여주는").theme(theme2).build());
 		}
 
 		@Test
@@ -216,9 +217,9 @@ public class RoutineServiceIntegrationTest {
 			final HappinessRoutineListGetServiceResponse actual = routineService.getHappinessRoutinesByTheme(request);
 
 			// then
-			assertThat(actual.routines()).hasSize(2);
+			Assertions.assertThat(actual.routines()).hasSize(2);
 			List<Long> routineIds = actual.routines().stream().map(HappinessRoutineServiceResponse::routineId).toList();
-			assertThat(routineIds).containsExactlyInAnyOrder(routine1.getId(), routine2.getId());
+			Assertions.assertThat(routineIds).containsExactlyInAnyOrder(routine1.getId(), routine2.getId());
 		}
 	}
 
@@ -237,9 +238,9 @@ public class RoutineServiceIntegrationTest {
 			theme = themeRepository.save(ThemeFixture.theme().name("관계 쌓기").color("라일락").build());
 
 			routine1 = routineRepository.save(
-				RoutineFixture.routine().type(CHALLENGE).content("관계쌓는").theme(theme).build());
+				RoutineFixture.routine().type(RoutineType.CHALLENGE).content("관계쌓는").theme(theme).build());
 			routine2 = routineRepository.save(
-				RoutineFixture.routine().type(CHALLENGE).content("성장하는").theme(theme).build());
+				RoutineFixture.routine().type(RoutineType.CHALLENGE).content("성장하는").theme(theme).build());
 
 			challenge1 = challengeRepository.save(ChallengeFixture.challenge().routine(routine1).build());
 			challenge2 = challengeRepository.save(ChallengeFixture.challenge().routine(routine1).build());
@@ -257,11 +258,11 @@ public class RoutineServiceIntegrationTest {
 			final HappinessSubRoutineListGetServiceResponse actual = routineService.getHappinessSubRoutines(request);
 
 			// then
-			assertThat(actual.challenges()).hasSize(2);
+			Assertions.assertThat(actual.challenges()).hasSize(2);
 
 			List<Long> challengeIds = actual.challenges().stream()
 				.map(HappinessSubRoutineServiceResponse::challengeId).toList();
-			assertThat(challengeIds).containsExactlyInAnyOrder(challenge1.getId(), challenge2.getId());
+			Assertions.assertThat(challengeIds).containsExactlyInAnyOrder(challenge1.getId(), challenge2.getId());
 		}
 	}
 }


### PR DESCRIPTION
## ✨ Related Issue
- close #298 
  <br/>

## 📝 기능 구현 명세

![image](https://github.com/Team-Sopetit/Sopetit-server/assets/55437339/dad59b3e-87d7-46ce-a90f-25b81f3101fc)


## 🐥 추가적인 언급 사항
- 파라미터 값으로 받은 테마 기준으로 루틴을 조회하는 기능이기 때문에, 테마 정보는 id 외에 생략했습니다.
- 파라미터 값으로 받은 테마 id 목록 값을 순서 그대로 반환하도록 했습니다.
  - LinkedHashMap 사용
  - stream()이 for문보다 느린 특징과, 사용시 가독성이 크게 향상되지 않는다는 점에서 for문 사용

- 파라미터 값으로 받는 theme id 목록에서 중복을 허용하지 않기 위해 Set 자료구조를 사용했습니다.