### PR TITLE
[FEAT] 도전 루틴 목록 조회

### DIFF
--- a/src/main/java/com/soptie/server/common/config/ValueConfig.java
+++ b/src/main/java/com/soptie/server/common/config/ValueConfig.java
@@ -49,6 +49,7 @@ public class ValueConfig {
 	public static final int MIN_COTTON_COUNT = 0;
 	public static final int DAILY_ROUTINE_MAX_COUNT = 3;
 	public static final String MEMBER_DOLL_CONDITION = "^[ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z]{1,10}$";
+	public static final long MEMBER_HAS_NOT_CHALLENGE = 0;
 
 	@PostConstruct
 	protected void init() {

--- a/src/main/java/com/soptie/server/memberroutine/repository/dto/MemberChallengeResponse.java
+++ b/src/main/java/com/soptie/server/memberroutine/repository/dto/MemberChallengeResponse.java
@@ -5,15 +5,17 @@ import com.soptie.server.memberroutine.entity.MemberRoutine;
 import com.soptie.server.routine.entity.Challenge;
 import com.soptie.server.theme.entity.Theme;
 
+import lombok.NonNull;
+
 public record MemberChallengeResponse(
-	Long id,
-	Long challengeId,
-	String routineContent,
-	String content,
-	String description,
-	String place,
-	String requiredTime,
-	Theme theme
+	long id,
+	long challengeId,
+	@NonNull String routineContent,
+	@NonNull String content,
+	@NonNull String description,
+	@NonNull String place,
+	@NonNull String requiredTime,
+	@NonNull Theme theme
 ) {
 
 	@QueryProjection

--- a/src/main/java/com/soptie/server/memberroutine/repository/dto/MemberChallengeResponse.java
+++ b/src/main/java/com/soptie/server/memberroutine/repository/dto/MemberChallengeResponse.java
@@ -7,6 +7,7 @@ import com.soptie.server.theme.entity.Theme;
 
 public record MemberChallengeResponse(
 	Long id,
+	Long challengeId,
 	String routineContent,
 	String content,
 	String description,
@@ -19,6 +20,7 @@ public record MemberChallengeResponse(
 	public MemberChallengeResponse(MemberRoutine memberRoutine, Challenge challenge, Theme theme) {
 		this(
 			memberRoutine.getId(),
+			challenge.getId(),
 			challenge.getRoutine().getContent(),
 			challenge.getContent(),
 			challenge.getDescription(),

--- a/src/main/java/com/soptie/server/routine/adapter/ChallengeFinder.java
+++ b/src/main/java/com/soptie/server/routine/adapter/ChallengeFinder.java
@@ -1,6 +1,6 @@
 package com.soptie.server.routine.adapter;
 
-import static com.soptie.server.routine.message.RoutineErrorCode.*;
+import static com.soptie.server.routine.message.RoutineErrorCode.INVALID_ROUTINE;
 
 import java.util.List;
 
@@ -9,6 +9,7 @@ import com.soptie.server.routine.entity.Challenge;
 import com.soptie.server.routine.entity.Routine;
 import com.soptie.server.routine.exception.RoutineException;
 import com.soptie.server.routine.repository.ChallengeRepository;
+import com.soptie.server.routine.service.vo.ChallengeVO;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,7 +24,7 @@ public class ChallengeFinder {
 			.orElseThrow(() -> new RoutineException(INVALID_ROUTINE));
 	}
 
-	public List<Challenge> findByRoutine(Routine routine) {
-		return challengeRepository.findByRoutine(routine);
+	public List<ChallengeVO> findByRoutine(Routine routine) {
+		return challengeRepository.findByRoutine(routine).stream().map(ChallengeVO::from).toList();
 	}
 }

--- a/src/main/java/com/soptie/server/routine/controller/v2/ChallengeRoutineControllerV2.java
+++ b/src/main/java/com/soptie/server/routine/controller/v2/ChallengeRoutineControllerV2.java
@@ -27,7 +27,7 @@ public class ChallengeRoutineControllerV2 implements ChallengeRoutineControllerV
 	@GetMapping
 	public ResponseEntity<SuccessResponse<ChallengeRoutineListAcquireResponseV2>> acquireAllByTheme(
 		Principal principal,
-		@RequestParam(value = "themeId") long themeId
+		@RequestParam long themeId
 	) {
 		val memberId = Long.parseLong(principal.getName());
 		val response = routineService.acquireAllInChallengeWithThemeId(memberId, themeId);

--- a/src/main/java/com/soptie/server/routine/controller/v2/ChallengeRoutineControllerV2.java
+++ b/src/main/java/com/soptie/server/routine/controller/v2/ChallengeRoutineControllerV2.java
@@ -1,0 +1,38 @@
+package com.soptie.server.routine.controller.v2;
+
+import java.security.Principal;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.soptie.server.common.dto.SuccessResponse;
+import com.soptie.server.routine.controller.v2.docs.ChallengeRoutineControllerV2Docs;
+import com.soptie.server.routine.controller.v2.dto.response.ChallengeRoutineListAcquireResponseV2;
+import com.soptie.server.routine.message.RoutineSuccessMessage;
+import com.soptie.server.routine.service.RoutineService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/routines/challenge")
+public class ChallengeRoutineControllerV2 implements ChallengeRoutineControllerV2Docs {
+
+	private final RoutineService routineService;
+
+	@GetMapping
+	public ResponseEntity<SuccessResponse<ChallengeRoutineListAcquireResponseV2>> acquireAllByTheme(
+		Principal principal,
+		@RequestParam(value = "themeId") Long themeId
+	) {
+		val memberId = Long.parseLong(principal.getName());
+		val response = routineService.acquireAllInChallengeWithThemeId(memberId, themeId);
+		return ResponseEntity.ok(SuccessResponse.success(
+			RoutineSuccessMessage.SUCCESS_GET_CHALLENGE_ROUTINE.getMessage(),
+			ChallengeRoutineListAcquireResponseV2.from(response)));
+	}
+}

--- a/src/main/java/com/soptie/server/routine/controller/v2/ChallengeRoutineControllerV2.java
+++ b/src/main/java/com/soptie/server/routine/controller/v2/ChallengeRoutineControllerV2.java
@@ -27,7 +27,7 @@ public class ChallengeRoutineControllerV2 implements ChallengeRoutineControllerV
 	@GetMapping
 	public ResponseEntity<SuccessResponse<ChallengeRoutineListAcquireResponseV2>> acquireAllByTheme(
 		Principal principal,
-		@RequestParam(value = "themeId") Long themeId
+		@RequestParam(value = "themeId") long themeId
 	) {
 		val memberId = Long.parseLong(principal.getName());
 		val response = routineService.acquireAllInChallengeWithThemeId(memberId, themeId);

--- a/src/main/java/com/soptie/server/routine/controller/v2/docs/ChallengeRoutineControllerV2Docs.java
+++ b/src/main/java/com/soptie/server/routine/controller/v2/docs/ChallengeRoutineControllerV2Docs.java
@@ -1,0 +1,46 @@
+package com.soptie.server.routine.controller.v2.docs;
+
+import java.security.Principal;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.soptie.server.common.dto.ErrorResponse;
+import com.soptie.server.common.dto.SuccessResponse;
+import com.soptie.server.routine.controller.v2.dto.response.ChallengeRoutineListAcquireResponseV2;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "challenge routines V2", description = "도전 루틴 API Version2")
+public interface ChallengeRoutineControllerV2Docs {
+
+	@Operation(
+		summary = "테마별 도전 루틴 목록 조회",
+		description = "테마에 해당되는 도전 루틴 목록을 조회한다.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "성공"),
+			@ApiResponse(
+				responseCode = "4xx",
+				description = "클라이언트(요청) 오류",
+				content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+			@ApiResponse(
+				responseCode = "500",
+				description = "서버 내부 오류",
+				content = @Content(schema = @Schema(implementation = ErrorResponse.class)))}
+	)
+	ResponseEntity<SuccessResponse<ChallengeRoutineListAcquireResponseV2>> acquireAllByTheme(
+		@Parameter(hidden = true) Principal principal,
+		@Parameter(
+			name = "themeId",
+			description = "조회할 도전 루틴 테마 id",
+			in = ParameterIn.QUERY,
+			example = "1"
+		) @RequestParam Long themeId
+	);
+}

--- a/src/main/java/com/soptie/server/routine/controller/v2/docs/ChallengeRoutineControllerV2Docs.java
+++ b/src/main/java/com/soptie/server/routine/controller/v2/docs/ChallengeRoutineControllerV2Docs.java
@@ -41,6 +41,6 @@ public interface ChallengeRoutineControllerV2Docs {
 			description = "조회할 도전 루틴 테마 id",
 			in = ParameterIn.QUERY,
 			example = "1"
-		) @RequestParam Long themeId
+		) @RequestParam long themeId
 	);
 }

--- a/src/main/java/com/soptie/server/routine/controller/v2/dto/response/ChallengeRoutineListAcquireResponseV2.java
+++ b/src/main/java/com/soptie/server/routine/controller/v2/dto/response/ChallengeRoutineListAcquireResponseV2.java
@@ -3,7 +3,7 @@ package com.soptie.server.routine.controller.v2.dto.response;
 import java.util.List;
 import java.util.Map;
 
-import com.soptie.server.routine.service.vo.ChallengeVO;
+import com.soptie.server.routine.service.dto.response.ChallengeRoutineListAcquireServiceResponse;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -11,10 +11,12 @@ import lombok.NonNull;
 
 @Builder(access = AccessLevel.PRIVATE)
 public record ChallengeRoutineListAcquireResponseV2(
-	List<RoutineResponse> routines
+	@NonNull List<RoutineResponse> routines
 ) {
 
-	public static ChallengeRoutineListAcquireResponseV2 from(Map<String, List<ChallengeVO>> challengesMap) {
+	public static ChallengeRoutineListAcquireResponseV2 from(
+		Map<String, ChallengeRoutineListAcquireServiceResponse> challengesMap
+	) {
 		return ChallengeRoutineListAcquireResponseV2.builder()
 			.routines(challengesMap.keySet()
 				.stream()
@@ -26,13 +28,13 @@ public record ChallengeRoutineListAcquireResponseV2(
 	@Builder(access = AccessLevel.PRIVATE)
 	private record RoutineResponse(
 		@NonNull String title,
-		List<ChallengeResponse> challenges
+		@NonNull List<ChallengeResponse> challenges
 	) {
 
-		private static RoutineResponse from(String title, List<ChallengeVO> challenges) {
+		private static RoutineResponse from(String title, ChallengeRoutineListAcquireServiceResponse challenges) {
 			return RoutineResponse.builder()
 				.title(title)
-				.challenges(challenges.stream().map(ChallengeResponse::from).toList())
+				.challenges(challenges.challenges().stream().map(ChallengeResponse::from).toList())
 				.build();
 		}
 	}
@@ -47,13 +49,14 @@ public record ChallengeRoutineListAcquireResponseV2(
 		boolean hasRoutine
 	) {
 
-		private static ChallengeResponse from(ChallengeVO challenge) {
+		private static ChallengeResponse from(
+			ChallengeRoutineListAcquireServiceResponse.ChallengeRoutineAcquireResponse challenge) {
 			return ChallengeResponse.builder()
-				.challengeId(challenge.challengeId())
-				.content(challenge.content())
-				.description(challenge.description())
-				.requiredTime(challenge.requiredTime())
-				.place(challenge.place())
+				.challengeId(challenge.challenge().challengeId())
+				.content(challenge.challenge().content())
+				.description(challenge.challenge().description())
+				.requiredTime(challenge.challenge().requiredTime())
+				.place(challenge.challenge().place())
 				.hasRoutine(challenge.hasRoutine())
 				.build();
 		}

--- a/src/main/java/com/soptie/server/routine/controller/v2/dto/response/ChallengeRoutineListAcquireResponseV2.java
+++ b/src/main/java/com/soptie/server/routine/controller/v2/dto/response/ChallengeRoutineListAcquireResponseV2.java
@@ -1,0 +1,61 @@
+package com.soptie.server.routine.controller.v2.dto.response;
+
+import java.util.List;
+import java.util.Map;
+
+import com.soptie.server.routine.service.vo.ChallengeVO;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NonNull;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record ChallengeRoutineListAcquireResponseV2(
+	List<RoutineResponse> routines
+) {
+
+	public static ChallengeRoutineListAcquireResponseV2 from(Map<String, List<ChallengeVO>> challengesMap) {
+		return ChallengeRoutineListAcquireResponseV2.builder()
+			.routines(challengesMap.keySet()
+				.stream()
+				.map(key -> RoutineResponse.from(key, challengesMap.get(key)))
+				.toList())
+			.build();
+	}
+
+	@Builder(access = AccessLevel.PRIVATE)
+	private record RoutineResponse(
+		@NonNull String title,
+		List<ChallengeResponse> challenges
+	) {
+
+		private static RoutineResponse from(String title, List<ChallengeVO> challenges) {
+			return RoutineResponse.builder()
+				.title(title)
+				.challenges(challenges.stream().map(ChallengeResponse::from).toList())
+				.build();
+		}
+	}
+
+	@Builder(access = AccessLevel.PRIVATE)
+	private record ChallengeResponse(
+		long challengeId,
+		@NonNull String content,
+		@NonNull String description,
+		@NonNull String requiredTime,
+		@NonNull String place,
+		boolean hasRoutine
+	) {
+
+		private static ChallengeResponse from(ChallengeVO challenge) {
+			return ChallengeResponse.builder()
+				.challengeId(challenge.challengeId())
+				.content(challenge.content())
+				.description(challenge.description())
+				.requiredTime(challenge.requiredTime())
+				.place(challenge.place())
+				.hasRoutine(challenge.hasRoutine())
+				.build();
+		}
+	}
+}

--- a/src/main/java/com/soptie/server/routine/message/RoutineSuccessMessage.java
+++ b/src/main/java/com/soptie/server/routine/message/RoutineSuccessMessage.java
@@ -9,6 +9,7 @@ public enum RoutineSuccessMessage {
 
 	SUCCESS_GET_ROUTINE("데일리 루틴 조회 성공"),
 	SUCCESS_GET_HAPPINESS_ROUTINE("행복 루틴 조회 성공"),
+	SUCCESS_GET_CHALLENGE_ROUTINE("도전 루틴 조회 성공"),
 	SUCCESS_GET_HAPPINESS_SUB_ROUTINES("행복 루틴 별 서브 루틴 리스트 조회 성공");
 
 	private final String message;

--- a/src/main/java/com/soptie/server/routine/service/RoutineService.java
+++ b/src/main/java/com/soptie/server/routine/service/RoutineService.java
@@ -1,6 +1,6 @@
 package com.soptie.server.routine.service;
 
-import static com.soptie.server.common.config.ValueConfig.*;
+import static com.soptie.server.common.config.ValueConfig.MEMBER_HAS_NOT_CHALLENGE;
 
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/src/main/java/com/soptie/server/routine/service/RoutineService.java
+++ b/src/main/java/com/soptie/server/routine/service/RoutineService.java
@@ -16,16 +16,15 @@ import com.soptie.server.memberroutine.adapter.MemberRoutineFinder;
 import com.soptie.server.memberroutine.repository.dto.MemberChallengeResponse;
 import com.soptie.server.routine.adapter.ChallengeFinder;
 import com.soptie.server.routine.adapter.RoutineFinder;
-import com.soptie.server.routine.entity.Challenge;
 import com.soptie.server.routine.entity.RoutineType;
 import com.soptie.server.routine.service.dto.request.DailyRoutineListByThemeGetServiceRequest;
 import com.soptie.server.routine.service.dto.request.DailyRoutineListByThemesGetServiceRequest;
 import com.soptie.server.routine.service.dto.request.HappinessRoutineListGetServiceRequest;
 import com.soptie.server.routine.service.dto.request.HappinessSubRoutineListGetServiceRequest;
+import com.soptie.server.routine.service.dto.response.ChallengeRoutineListAcquireServiceResponse;
 import com.soptie.server.routine.service.dto.response.DailyRoutineListGetServiceResponse;
 import com.soptie.server.routine.service.dto.response.HappinessRoutineListGetServiceResponse;
 import com.soptie.server.routine.service.dto.response.HappinessSubRoutineListGetServiceResponse;
-import com.soptie.server.routine.service.vo.ChallengeVO;
 import com.soptie.server.routine.service.vo.RoutineVO;
 import com.soptie.server.theme.adapter.ThemeFinder;
 
@@ -79,15 +78,17 @@ public class RoutineService {
 		return themeToRoutine;
 	}
 
-	public Map<String, List<ChallengeVO>> acquireAllInChallengeWithThemeId(long memberId, long themeId) {
+	public Map<String, ChallengeRoutineListAcquireServiceResponse> acquireAllInChallengeWithThemeId(long memberId,
+		long themeId) {
 		themeFinder.isExistById(themeId);
 		val member = memberFinder.findById(memberId);
 		val challengeIdByMember = getChallengeIdByMember(member);
 		val challengeRoutinesByTheme = routineFinder.findChallengeRoutinesByTheme(themeId);
-		val themeToChallenge = new LinkedHashMap<String, List<ChallengeVO>>();
+		val themeToChallenge = new LinkedHashMap<String, ChallengeRoutineListAcquireServiceResponse>();
 		for (val routine : challengeRoutinesByTheme) {
 			val challenges = challengeFinder.findByRoutine(routine);
-			themeToChallenge.put(routine.getContent(), getChallengeVOs(challenges, challengeIdByMember));
+			themeToChallenge.put(routine.getContent(),
+				ChallengeRoutineListAcquireServiceResponse.of(challenges, challengeIdByMember));
 		}
 		return themeToChallenge;
 	}
@@ -95,11 +96,5 @@ public class RoutineService {
 	private long getChallengeIdByMember(Member member) {
 		val challengeByMember = memberRoutineFinder.findChallengeByMember(member);
 		return challengeByMember.map(MemberChallengeResponse::challengeId).orElse(MEMBER_HAS_NOT_CHALLENGE);
-	}
-
-	private List<ChallengeVO> getChallengeVOs(List<Challenge> challenges, long challengeId) {
-		return challenges.stream()
-			.map(challenge -> ChallengeVO.from(challenge, challengeId))
-			.toList();
 	}
 }

--- a/src/main/java/com/soptie/server/routine/service/RoutineService.java
+++ b/src/main/java/com/soptie/server/routine/service/RoutineService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.soptie.server.member.adapter.MemberFinder;
 import com.soptie.server.member.entity.Member;
 import com.soptie.server.memberroutine.adapter.MemberRoutineFinder;
+import com.soptie.server.memberroutine.repository.dto.MemberChallengeResponse;
 import com.soptie.server.routine.adapter.ChallengeFinder;
 import com.soptie.server.routine.adapter.RoutineFinder;
 import com.soptie.server.routine.entity.Challenge;
@@ -93,10 +94,7 @@ public class RoutineService {
 
 	private long getChallengeIdByMember(Member member) {
 		val challengeByMember = memberRoutineFinder.findChallengeByMember(member);
-		if (challengeByMember.isPresent()) {
-			return challengeByMember.get().challengeId();
-		}
-		return MEMBER_HAS_NOT_CHALLENGE;
+		return challengeByMember.map(MemberChallengeResponse::challengeId).orElse(MEMBER_HAS_NOT_CHALLENGE);
 	}
 
 	private List<ChallengeVO> getChallengeVOs(List<Challenge> challenges, long challengeId) {

--- a/src/main/java/com/soptie/server/routine/service/RoutineService.java
+++ b/src/main/java/com/soptie/server/routine/service/RoutineService.java
@@ -80,7 +80,7 @@ public class RoutineService {
 	}
 
 	public Map<String, List<ChallengeVO>> acquireAllInChallengeWithThemeId(long memberId, long themeId) {
-		themeFinder.findById(themeId);
+		themeFinder.isExistById(themeId);
 		val member = memberFinder.findById(memberId);
 		val challengeIdByMember = getChallengeIdByMember(member);
 		val challengeRoutinesByTheme = routineFinder.findChallengeRoutinesByTheme(themeId);

--- a/src/main/java/com/soptie/server/routine/service/dto/response/ChallengeRoutineListAcquireServiceResponse.java
+++ b/src/main/java/com/soptie/server/routine/service/dto/response/ChallengeRoutineListAcquireServiceResponse.java
@@ -1,0 +1,38 @@
+package com.soptie.server.routine.service.dto.response;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import java.util.List;
+
+import com.soptie.server.routine.service.vo.ChallengeVO;
+
+import lombok.Builder;
+import lombok.NonNull;
+
+@Builder(access = PRIVATE)
+public record ChallengeRoutineListAcquireServiceResponse(
+	@NonNull List<ChallengeRoutineAcquireResponse> challenges
+) {
+
+	public static ChallengeRoutineListAcquireServiceResponse of(List<ChallengeVO> challenges, long challengeId) {
+		return ChallengeRoutineListAcquireServiceResponse.builder()
+			.challenges(challenges.stream()
+				.map(challenge -> ChallengeRoutineAcquireResponse.of(challenge, challengeId))
+				.toList())
+			.build();
+	}
+
+	@Builder(access = PRIVATE)
+	public record ChallengeRoutineAcquireResponse(
+		ChallengeVO challenge,
+		boolean hasRoutine
+	) {
+
+		public static ChallengeRoutineAcquireResponse of(ChallengeVO challenge, long challengeId) {
+			return ChallengeRoutineAcquireResponse.builder()
+				.challenge(challenge)
+				.hasRoutine(challenge.challengeId() == challengeId)
+				.build();
+		}
+	}
+}

--- a/src/main/java/com/soptie/server/routine/service/dto/response/HappinessSubRoutineListGetServiceResponse.java
+++ b/src/main/java/com/soptie/server/routine/service/dto/response/HappinessSubRoutineListGetServiceResponse.java
@@ -1,11 +1,11 @@
 package com.soptie.server.routine.service.dto.response;
 
-import static lombok.AccessLevel.*;
+import static lombok.AccessLevel.PRIVATE;
 
 import java.util.List;
 
-import com.soptie.server.routine.entity.Challenge;
 import com.soptie.server.routine.entity.Routine;
+import com.soptie.server.routine.service.vo.ChallengeVO;
 
 import lombok.Builder;
 
@@ -16,7 +16,7 @@ public record HappinessSubRoutineListGetServiceResponse(
 	List<HappinessSubRoutineServiceResponse> challenges
 ) {
 
-	public static HappinessSubRoutineListGetServiceResponse of(Routine routine, List<Challenge> challenges) {
+	public static HappinessSubRoutineListGetServiceResponse of(Routine routine, List<ChallengeVO> challenges) {
 		return HappinessSubRoutineListGetServiceResponse.builder()
 			.routineContent(routine.getContent())
 			.themeName(routine.getTheme().getName())
@@ -33,13 +33,13 @@ public record HappinessSubRoutineListGetServiceResponse(
 		String requiredTime, String place
 	) {
 
-		private static HappinessSubRoutineServiceResponse of(Challenge challenge) {
+		private static HappinessSubRoutineServiceResponse of(ChallengeVO challenge) {
 			return HappinessSubRoutineServiceResponse.builder()
-				.challengeId(challenge.getId())
-				.content(challenge.getContent())
-				.description(challenge.getDescription())
-				.requiredTime(challenge.getRequiredTime())
-				.place(challenge.getPlace())
+				.challengeId(challenge.challengeId())
+				.content(challenge.content())
+				.description(challenge.description())
+				.requiredTime(challenge.requiredTime())
+				.place(challenge.place())
 				.build();
 		}
 	}

--- a/src/main/java/com/soptie/server/routine/service/vo/ChallengeVO.java
+++ b/src/main/java/com/soptie/server/routine/service/vo/ChallengeVO.java
@@ -12,18 +12,16 @@ public record ChallengeVO(
 	@NonNull String content,
 	@NonNull String description,
 	@NonNull String requiredTime,
-	@NonNull String place,
-	boolean hasRoutine
+	@NonNull String place
 ) {
 
-	public static ChallengeVO from(Challenge challenge, long challengeId) {
+	public static ChallengeVO from(Challenge challenge) {
 		return ChallengeVO.builder()
 			.challengeId(challenge.getId())
 			.content(challenge.getContent())
 			.description(challenge.getDescription())
 			.requiredTime(challenge.getRequiredTime())
 			.place(challenge.getPlace())
-			.hasRoutine(challenge.getId().equals(challengeId))
 			.build();
 	}
 }

--- a/src/main/java/com/soptie/server/routine/service/vo/ChallengeVO.java
+++ b/src/main/java/com/soptie/server/routine/service/vo/ChallengeVO.java
@@ -1,0 +1,29 @@
+package com.soptie.server.routine.service.vo;
+
+import com.soptie.server.routine.entity.Challenge;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NonNull;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record ChallengeVO(
+	long challengeId,
+	@NonNull String content,
+	@NonNull String description,
+	@NonNull String requiredTime,
+	@NonNull String place,
+	boolean hasRoutine
+) {
+
+	public static ChallengeVO from(Challenge challenge, long challengeId) {
+		return ChallengeVO.builder()
+			.challengeId(challenge.getId())
+			.content(challenge.getContent())
+			.description(challenge.getDescription())
+			.requiredTime(challenge.getRequiredTime())
+			.place(challenge.getPlace())
+			.hasRoutine(challenge.getId().equals(challengeId))
+			.build();
+	}
+}

--- a/src/main/java/com/soptie/server/theme/adapter/ThemeFinder.java
+++ b/src/main/java/com/soptie/server/theme/adapter/ThemeFinder.java
@@ -1,6 +1,6 @@
 package com.soptie.server.theme.adapter;
 
-import static com.soptie.server.theme.message.ThemeErrorCode.*;
+import static com.soptie.server.theme.message.ThemeErrorCode.INVALID_THEME;
 
 import java.util.List;
 
@@ -23,10 +23,14 @@ public class ThemeFinder {
 
 	public Theme findById(long id) {
 		return themeRepository.findById(id)
-				.orElseThrow(() -> new ThemeException(INVALID_THEME));
+			.orElseThrow(() -> new ThemeException(INVALID_THEME));
 	}
 
 	public List<Theme> findAllInBasic() {
 		return themeRepository.findAllInBasic();
+	}
+
+	public boolean isExistById(long id) {
+		return themeRepository.existsById(id);
 	}
 }

--- a/src/test/java/com/soptie/server/memberroutine/service/integration/MemberRoutineServiceIntegrationTest.java
+++ b/src/test/java/com/soptie/server/memberroutine/service/integration/MemberRoutineServiceIntegrationTest.java
@@ -1,8 +1,11 @@
 package com.soptie.server.memberroutine.service.integration;
 
-import static com.soptie.server.routine.entity.RoutineType.*;
-import static com.soptie.server.routine.message.RoutineErrorCode.*;
-import static org.assertj.core.api.Assertions.*;
+import static com.soptie.server.routine.entity.RoutineType.CHALLENGE;
+import static com.soptie.server.routine.entity.RoutineType.DAILY;
+import static com.soptie.server.routine.message.RoutineErrorCode.CANNOT_ADD_MEMBER_ROUTINE;
+import static com.soptie.server.routine.message.RoutineErrorCode.DUPLICATED_ROUTINE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.Optional;
@@ -344,6 +347,8 @@ public class MemberRoutineServiceIntegrationTest {
 				ChallengeFixture.challenge()
 					.content("무한~ 도전~")
 					.description("무한으로 즐겨요")
+					.requiredTime("2시간")
+					.place("MBC")
 					.routine(challengeRoutine)
 					.build());
 			memberRoutineRepository.save(MemberRoutineFixture.memberRoutine()
@@ -416,6 +421,8 @@ public class MemberRoutineServiceIntegrationTest {
 				ChallengeFixture.challenge()
 					.content("무한~ 도전~")
 					.description("무한으로 즐겨요")
+					.requiredTime("2시간")
+					.place("MBC")
 					.routine(challengeRoutine)
 					.build());
 			memberRoutineRepository.save(MemberRoutineFixture.memberRoutine()

--- a/src/test/java/com/soptie/server/routine/service/integration/RoutineServiceIntegrationTest.java
+++ b/src/test/java/com/soptie/server/routine/service/integration/RoutineServiceIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.soptie.server.routine.service.integration;
 
+import static com.soptie.server.routine.entity.RoutineType.*;
+
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -15,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.soptie.server.member.entity.Member;
 import com.soptie.server.member.repository.MemberRepository;
+import com.soptie.server.memberroutine.entity.MemberRoutine;
 import com.soptie.server.memberroutine.repository.MemberRoutineRepository;
 import com.soptie.server.routine.entity.Challenge;
 import com.soptie.server.routine.entity.Routine;
@@ -32,6 +35,7 @@ import com.soptie.server.routine.service.dto.response.HappinessRoutineListGetSer
 import com.soptie.server.routine.service.dto.response.HappinessRoutineListGetServiceResponse.HappinessRoutineServiceResponse;
 import com.soptie.server.routine.service.dto.response.HappinessSubRoutineListGetServiceResponse;
 import com.soptie.server.routine.service.dto.response.HappinessSubRoutineListGetServiceResponse.HappinessSubRoutineServiceResponse;
+import com.soptie.server.routine.service.vo.ChallengeVO;
 import com.soptie.server.routine.service.vo.RoutineVO;
 import com.soptie.server.support.IntegrationTest;
 import com.soptie.server.support.fixture.ChallengeFixture;
@@ -159,7 +163,7 @@ public class RoutineServiceIntegrationTest {
 			routineMemberHas = routineRepository.save(
 				RoutineFixture.routine().type(RoutineType.DAILY).content("쌓자 관계").theme(theme).build());
 			challengeRoutine = routineRepository.save(
-				RoutineFixture.routine().type(RoutineType.CHALLENGE).content("관계 도전").theme(theme).build());
+				RoutineFixture.routine().type(CHALLENGE).content("관계 도전").theme(theme).build());
 
 			memberRoutineRepository.save(
 				MemberRoutineFixture.memberRoutine()
@@ -200,11 +204,11 @@ public class RoutineServiceIntegrationTest {
 			theme2 = themeRepository.save(ThemeFixture.theme().name("한 걸음 성장").color("민트").build());
 
 			routine1 = routineRepository.save(
-				RoutineFixture.routine().type(RoutineType.CHALLENGE).content("관계쌓는").theme(theme1).build());
+				RoutineFixture.routine().type(CHALLENGE).content("관계쌓는").theme(theme1).build());
 			routine2 = routineRepository.save(
-				RoutineFixture.routine().type(RoutineType.CHALLENGE).content("성장하는").theme(theme1).build());
+				RoutineFixture.routine().type(CHALLENGE).content("성장하는").theme(theme1).build());
 			routine3 = routineRepository.save(
-				RoutineFixture.routine().type(RoutineType.CHALLENGE).content("보여주는").theme(theme2).build());
+				RoutineFixture.routine().type(CHALLENGE).content("보여주는").theme(theme2).build());
 		}
 
 		@Test
@@ -238,9 +242,9 @@ public class RoutineServiceIntegrationTest {
 			theme = themeRepository.save(ThemeFixture.theme().name("관계 쌓기").color("라일락").build());
 
 			routine1 = routineRepository.save(
-				RoutineFixture.routine().type(RoutineType.CHALLENGE).content("관계쌓는").theme(theme).build());
+				RoutineFixture.routine().type(CHALLENGE).content("관계쌓는").theme(theme).build());
 			routine2 = routineRepository.save(
-				RoutineFixture.routine().type(RoutineType.CHALLENGE).content("성장하는").theme(theme).build());
+				RoutineFixture.routine().type(CHALLENGE).content("성장하는").theme(theme).build());
 
 			challenge1 = challengeRepository.save(ChallengeFixture.challenge().routine(routine1).build());
 			challenge2 = challengeRepository.save(ChallengeFixture.challenge().routine(routine1).build());
@@ -263,6 +267,95 @@ public class RoutineServiceIntegrationTest {
 			List<Long> challengeIds = actual.challenges().stream()
 				.map(HappinessSubRoutineServiceResponse::challengeId).toList();
 			Assertions.assertThat(challengeIds).containsExactlyInAnyOrder(challenge1.getId(), challenge2.getId());
+		}
+	}
+
+	@Nested
+	class AcquireChallengeByThemes {
+
+		Member member;
+		Challenge challenge1;
+		Challenge challenge2;
+		Challenge challenge3;
+		Routine routine1;
+		Routine routine2;
+		Theme theme;
+		MemberRoutine memberRoutine;
+
+		@BeforeEach
+		void setUp() {
+			member = memberRepository.save(MemberFixture.member().build());
+			theme = themeRepository.save(ThemeFixture.theme().name("관계 쌓기").color("라일락").build());
+
+			routine1 = routineRepository.save(
+				RoutineFixture.routine().type(CHALLENGE).content("관계쌓는").theme(theme).build());
+			routine2 = routineRepository.save(
+				RoutineFixture.routine().type(CHALLENGE).content("성장하는").theme(theme).build());
+
+			challenge1 = challengeRepository.save(
+				ChallengeFixture.challenge().routine(routine1)
+					.content("선배 마라탕 사주세요.")
+					.description("혹시 탕후루도 같이?")
+					.requiredTime("30분")
+					.place("소프티 숙소")
+					.build()
+			);
+			challenge2 = challengeRepository.save(
+				ChallengeFixture.challenge().routine(routine1)
+					.content("선배 탕후루 사주세요.")
+					.description("혹시 마라탕도 같이?")
+					.requiredTime("1시간")
+					.place("소프티 숙소")
+					.build()
+			);
+			challenge3 = challengeRepository.save(
+				ChallengeFixture.challenge().routine(routine2)
+					.content("선배")
+					.description("안된다고요?")
+					.requiredTime("10분")
+					.place("소프티 숙소")
+					.build()
+			);
+
+			memberRoutine = memberRoutineRepository.save(
+				MemberRoutineFixture.memberRoutine()
+					.type(CHALLENGE).routineId(challenge2.getId()).member(member).build()
+			);
+		}
+
+		@Test
+		@DisplayName("[성공] 테마에 속한 도전 루틴 목록을 조회한다. 이 때, 멤버가 가지고 있는 도전 루틴이라면 hasRoutine의 값이 true이다.")
+		void acquireAllByTheme() {
+			// given
+			long themeId = theme.getId();
+			long memberId = member.getId();
+
+			// when
+			final Map<String, List<ChallengeVO>> actual = routineService.acquireAllInChallengeWithThemeId(
+				memberId, themeId);
+
+			// then
+			Assertions.assertThat(actual.keySet())
+				.containsExactlyInAnyOrder(routine1.getContent(), routine2.getContent());
+
+			Assertions.assertThat(actual.get(routine1.getContent())).hasSize(2);
+			Assertions.assertThat(actual.get(routine2.getContent())).hasSize(1);
+
+			List<ChallengeVO> challenges = actual.get(routine1.getContent());
+			Assertions.assertThat(
+				challenges.stream()
+					.filter(challenge -> challenge.challengeId() == challenge1.getId())
+					.findAny()
+					.orElseThrow()
+					.hasRoutine()
+			).isEqualTo(false);
+			Assertions.assertThat(
+				challenges.stream()
+					.filter(challenge -> challenge.challengeId() == challenge2.getId())
+					.findAny()
+					.orElseThrow()
+					.hasRoutine()
+			).isEqualTo(true);
 		}
 	}
 }

--- a/src/test/java/com/soptie/server/routine/service/integration/RoutineServiceIntegrationTest.java
+++ b/src/test/java/com/soptie/server/routine/service/integration/RoutineServiceIntegrationTest.java
@@ -29,13 +29,13 @@ import com.soptie.server.routine.service.dto.request.DailyRoutineListByThemeGetS
 import com.soptie.server.routine.service.dto.request.DailyRoutineListByThemesGetServiceRequest;
 import com.soptie.server.routine.service.dto.request.HappinessRoutineListGetServiceRequest;
 import com.soptie.server.routine.service.dto.request.HappinessSubRoutineListGetServiceRequest;
+import com.soptie.server.routine.service.dto.response.ChallengeRoutineListAcquireServiceResponse;
 import com.soptie.server.routine.service.dto.response.DailyRoutineListGetServiceResponse;
 import com.soptie.server.routine.service.dto.response.DailyRoutineListGetServiceResponse.DailyRoutineServiceResponse;
 import com.soptie.server.routine.service.dto.response.HappinessRoutineListGetServiceResponse;
 import com.soptie.server.routine.service.dto.response.HappinessRoutineListGetServiceResponse.HappinessRoutineServiceResponse;
 import com.soptie.server.routine.service.dto.response.HappinessSubRoutineListGetServiceResponse;
 import com.soptie.server.routine.service.dto.response.HappinessSubRoutineListGetServiceResponse.HappinessSubRoutineServiceResponse;
-import com.soptie.server.routine.service.vo.ChallengeVO;
 import com.soptie.server.routine.service.vo.RoutineVO;
 import com.soptie.server.support.IntegrationTest;
 import com.soptie.server.support.fixture.ChallengeFixture;
@@ -246,9 +246,33 @@ public class RoutineServiceIntegrationTest {
 			routine2 = routineRepository.save(
 				RoutineFixture.routine().type(CHALLENGE).content("성장하는").theme(theme).build());
 
-			challenge1 = challengeRepository.save(ChallengeFixture.challenge().routine(routine1).build());
-			challenge2 = challengeRepository.save(ChallengeFixture.challenge().routine(routine1).build());
-			challenge3 = challengeRepository.save(ChallengeFixture.challenge().routine(routine2).build());
+			challenge1 = challengeRepository.save(
+				ChallengeFixture.challenge()
+					.content("도전 루틴 내용")
+					.description("도전 루틴 설명")
+					.requiredTime("10분")
+					.place("소프티 숙소")
+					.routine(routine1)
+					.build()
+			);
+			challenge2 = challengeRepository.save(
+				ChallengeFixture.challenge()
+					.content("도전 루틴 내용")
+					.description("도전 루틴 설명")
+					.requiredTime("10분")
+					.place("소프티 숙소")
+					.routine(routine1)
+					.build()
+			);
+			challenge3 = challengeRepository.save(
+				ChallengeFixture.challenge()
+					.content("도전 루틴 내용")
+					.description("도전 루틴 설명")
+					.requiredTime("10분")
+					.place("소프티 숙소")
+					.routine(routine2)
+					.build()
+			);
 		}
 
 		@Test
@@ -331,27 +355,24 @@ public class RoutineServiceIntegrationTest {
 			long memberId = member.getId();
 
 			// when
-			final Map<String, List<ChallengeVO>> actual = routineService.acquireAllInChallengeWithThemeId(
-				memberId, themeId);
+			final Map<String, ChallengeRoutineListAcquireServiceResponse> actual =
+				routineService.acquireAllInChallengeWithThemeId(memberId, themeId);
 
 			// then
 			Assertions.assertThat(actual.keySet())
 				.containsExactlyInAnyOrder(routine1.getContent(), routine2.getContent());
 
-			Assertions.assertThat(actual.get(routine1.getContent())).hasSize(2);
-			Assertions.assertThat(actual.get(routine2.getContent())).hasSize(1);
-
-			List<ChallengeVO> challenges = actual.get(routine1.getContent());
+			ChallengeRoutineListAcquireServiceResponse challenges = actual.get(routine1.getContent());
 			Assertions.assertThat(
-				challenges.stream()
-					.filter(challenge -> challenge.challengeId() == challenge1.getId())
+				challenges.challenges().stream()
+					.filter(challenge -> challenge.challenge().challengeId() == challenge1.getId())
 					.findAny()
 					.orElseThrow()
 					.hasRoutine()
 			).isEqualTo(false);
 			Assertions.assertThat(
-				challenges.stream()
-					.filter(challenge -> challenge.challengeId() == challenge2.getId())
+				challenges.challenges().stream()
+					.filter(challenge -> challenge.challenge().challengeId() == challenge2.getId())
 					.findAny()
 					.orElseThrow()
 					.hasRoutine()

--- a/src/test/java/com/soptie/server/routine/service/integration/RoutineServiceIntegrationTest.java
+++ b/src/test/java/com/soptie/server/routine/service/integration/RoutineServiceIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.soptie.server.routine.service.integration;
 
-import static com.soptie.server.routine.entity.RoutineType.*;
+import static com.soptie.server.routine.entity.RoutineType.CHALLENGE;
 
 import java.util.LinkedHashSet;
 import java.util.List;


### PR DESCRIPTION
## ✨ Related Issue
- close #284 
  <br/>

## 📝 기능 구현 명세
![image](https://github.com/Team-Sopetit/Sopetit-server/assets/81404890/6cd84655-84b3-4941-b03c-9ea156eb5649)
- 도전 루틴 조회 api
![image](https://github.com/Team-Sopetit/Sopetit-server/assets/81404890/86ef9fb0-21e8-4f42-a3d7-5843dcbebecf)
- 도전 루틴 조회 테스트

## 🐥 추가적인 언급 사항
- 계속해서 리뷰해주신 VO 활용, dto를 좀 더 깔끔하게 작성해보고자 노력했습니다!
- 소현님이 이전에 작성해주신 코드 참고해서 더 원활하게 짤 수 있었습니다.