### PR TITLE
[ADD] 데일리 루틴 달성 취소 로직 추가

### DIFF
--- a/src/main/java/com/soptie/server/memberroutine/controller/v1/MemberDailyRoutineController.java
+++ b/src/main/java/com/soptie/server/memberroutine/controller/v1/MemberDailyRoutineController.java
@@ -77,7 +77,7 @@ public class MemberDailyRoutineController implements MemberDailyRoutineControlle
 	) {
 		val memberId = Long.parseLong(principal.getName());
 		val response = MemberDailyRoutineAchieveResponse
-			.of(memberRoutineUpdateService.achieveMemberRoutine(
+			.of(memberRoutineUpdateService.updateAchievementStatus(
 				MemberRoutineAchieveServiceRequest.of(memberId, routineId)));
 		return ResponseEntity.ok(success(SUCCESS_ACHIEVE_ROUTINE.getMessage(), response));
 	}

--- a/src/main/java/com/soptie/server/memberroutine/controller/v1/MemberHappinessRoutineController.java
+++ b/src/main/java/com/soptie/server/memberroutine/controller/v1/MemberHappinessRoutineController.java
@@ -81,7 +81,7 @@ public class MemberHappinessRoutineController implements MemberHappinessRoutineC
 		@PathVariable Long routineId
 	) {
 		val memberId = Long.parseLong(principal.getName());
-		memberRoutineUpdateService.achieveMemberRoutine(MemberRoutineAchieveServiceRequest.of(memberId, routineId));
+		memberRoutineUpdateService.updateAchievementStatus(MemberRoutineAchieveServiceRequest.of(memberId, routineId));
 		return ResponseEntity.ok(success(SUCCESS_ACHIEVE_ROUTINE.getMessage()));
 	}
 }

--- a/src/main/java/com/soptie/server/memberroutine/controller/v1/dto/response/MemberDailyRoutineAchieveResponse.java
+++ b/src/main/java/com/soptie/server/memberroutine/controller/v1/dto/response/MemberDailyRoutineAchieveResponse.java
@@ -10,7 +10,8 @@ import lombok.Builder;
 public record MemberDailyRoutineAchieveResponse(
 	long routineId,
 	boolean isAchieve,
-	int achieveCount
+	int achieveCount,
+	boolean hasCotton
 ) {
 
 	public static MemberDailyRoutineAchieveResponse of(MemberRoutineAchieveServiceResponse response) {
@@ -18,6 +19,7 @@ public record MemberDailyRoutineAchieveResponse(
 			.routineId(response.routineId())
 			.isAchieve(response.isAchieve())
 			.achieveCount(response.achieveCount())
+			.hasCotton(response.hasCotton())
 			.build();
 	}
 }

--- a/src/main/java/com/soptie/server/memberroutine/entity/MemberRoutine.java
+++ b/src/main/java/com/soptie/server/memberroutine/entity/MemberRoutine.java
@@ -36,6 +36,8 @@ public class MemberRoutine {
 
 	private boolean isAchieve;
 
+	private boolean isAchieveToday;
+
 	private int achieveCount;
 
 	@Enumerated(value = STRING)
@@ -49,6 +51,7 @@ public class MemberRoutine {
 
 	public MemberRoutine(Member member, Routine routine) {
 		this.isAchieve = false;
+		this.isAchieveToday = false;
 		this.achieveCount = 0;
 		this.type = routine.getType();
 		this.routineId = routine.getId();
@@ -57,6 +60,7 @@ public class MemberRoutine {
 
 	public MemberRoutine(Member member, Challenge challenge) {
 		this.isAchieve = false;
+		this.isAchieveToday = false;
 		this.achieveCount = 0;
 		this.type = CHALLENGE;
 		this.routineId = challenge.getId();
@@ -65,6 +69,7 @@ public class MemberRoutine {
 
 	public MemberRoutine(DeletedMemberRoutine deletedMemberRoutine) {
 		this.isAchieve = isAchievedToday(deletedMemberRoutine);
+		this.isAchieveToday = isAchievedToday(deletedMemberRoutine);
 		this.achieveCount = deletedMemberRoutine.getAchieveCount();
 		this.type = deletedMemberRoutine.getType();
 		this.routineId = deletedMemberRoutine.getRoutineId();
@@ -77,6 +82,7 @@ public class MemberRoutine {
 	) {
 		this.id = id;
 		this.isAchieve = isAchieve;
+		this.isAchieveToday = isAchieve;
 		this.achieveCount = achieveCount;
 		this.type = type;
 		this.routineId = routineId;
@@ -85,11 +91,18 @@ public class MemberRoutine {
 
 	public void achieve() {
 		this.isAchieve = true;
+		this.isAchieveToday = true;
 		this.achieveCount++;
 	}
 
 	public void initAchieve() {
 		this.isAchieve = false;
+		this.isAchieveToday = false;
+	}
+
+	public void cancelAchievement() {
+		this.isAchieve = false;
+		this.achieveCount--;
 	}
 
 	public void checkMemberHas(Member member) {

--- a/src/main/java/com/soptie/server/memberroutine/service/MemberRoutineUpdateService.java
+++ b/src/main/java/com/soptie/server/memberroutine/service/MemberRoutineUpdateService.java
@@ -24,7 +24,7 @@ public class MemberRoutineUpdateService {
 	private final MemberRoutineDeleter memberRoutineDeleter;
 	private final MemberFinder memberFinder;
 
-	public MemberRoutineAchieveServiceResponse achieveMemberRoutine(MemberRoutineAchieveServiceRequest request) {
+	public MemberRoutineAchieveServiceResponse updateAchievementStatus(MemberRoutineAchieveServiceRequest request) {
 		val member = memberFinder.findById(request.memberId());
 		val memberRoutine = memberRoutineFinder.findById(request.memberRoutineId());
 		val isAchievedToday = memberRoutine.isAchieveToday();

--- a/src/main/java/com/soptie/server/memberroutine/service/MemberRoutineUpdateService.java
+++ b/src/main/java/com/soptie/server/memberroutine/service/MemberRoutineUpdateService.java
@@ -1,13 +1,11 @@
 package com.soptie.server.memberroutine.service;
 
-import static com.soptie.server.member.message.ErrorCode.*;
 import static com.soptie.server.routine.entity.RoutineType.*;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.soptie.server.member.adapter.MemberFinder;
-import com.soptie.server.member.exception.MemberException;
 import com.soptie.server.memberroutine.adapter.MemberRoutineDeleter;
 import com.soptie.server.memberroutine.adapter.MemberRoutineFinder;
 import com.soptie.server.memberroutine.entity.MemberRoutine;
@@ -31,9 +29,7 @@ public class MemberRoutineUpdateService {
 		val memberRoutine = memberRoutineFinder.findById(request.memberRoutineId());
 		val isAchievedToday = memberRoutine.isAchieveToday();
 
-		if (memberRoutine.getMember() != member) {
-			throw new MemberException(INACCESSIBLE_ROUTINE);
-		}
+		memberRoutine.checkMemberHas(member);
 
 		if (memberRoutine.isAchieve()) {
 			memberRoutine.cancelAchievement();

--- a/src/main/java/com/soptie/server/memberroutine/service/dto/response/MemberRoutineAchieveServiceResponse.java
+++ b/src/main/java/com/soptie/server/memberroutine/service/dto/response/MemberRoutineAchieveServiceResponse.java
@@ -10,14 +10,16 @@ import lombok.Builder;
 public record MemberRoutineAchieveServiceResponse(
 	long routineId,
 	boolean isAchieve,
-	int achieveCount
+	int achieveCount,
+	boolean hasCotton
 ) {
 
-	public static MemberRoutineAchieveServiceResponse of(MemberRoutine routine) {
+	public static MemberRoutineAchieveServiceResponse of(MemberRoutine routine, boolean hasCotton) {
 		return MemberRoutineAchieveServiceResponse.builder()
 			.routineId(routine.getId())
 			.isAchieve(routine.isAchieve())
 			.achieveCount(routine.getAchieveCount())
+			.hasCotton(hasCotton)
 			.build();
 	}
 }

--- a/src/test/java/com/soptie/server/memberroutine/service/MemberRoutineServiceTest.java
+++ b/src/test/java/com/soptie/server/memberroutine/service/MemberRoutineServiceTest.java
@@ -63,7 +63,7 @@ class MemberRoutineServiceTest {
 			memberRoutine.getId());
 
 		// when
-		memberRoutineUpdateService.achieveMemberRoutine(request);
+		memberRoutineUpdateService.updateAchievementStatus(request);
 
 		// then
 		assertThat(memberRoutine.isAchieve()).isTrue();
@@ -95,7 +95,7 @@ class MemberRoutineServiceTest {
 			memberRoutine.getId());
 
 		// when
-		memberRoutineUpdateService.achieveMemberRoutine(request);
+		memberRoutineUpdateService.updateAchievementStatus(request);
 
 		// then
 		assertThat(memberRoutine.isAchieve()).isTrue();


### PR DESCRIPTION
## ✨ Related Issue
- close #274 
  <br/>

## 📝 기능 구현 명세

![image](https://github.com/user-attachments/assets/68e264e2-63d2-4124-83ee-e3046e85a532)


## 🐥 추가적인 언급 사항
- 캐시 누락 사유
  - 캐시를 사용하기 위해서는 복구를 위한 원본 데이터가 필요합니다.
  - 의논한 로직에서는 원본 데이터(ex. 취소 이력)를 담고 있지 않기 때문에 캐싱 장애 발생 시 데이터를 복구할 길이 없습니다.
  - 따라서 캐싱을 진행하지 않고, isAchieveToday 칼럼 하나로 로직 체크가 충분히 가능하다고 판단하여 이처럼 진행했습니다.