### PR TITLE
[FEAT] 회원 정보 조회 API

### DIFF
--- a/src/main/java/com/soptie/server/api/controller/MemberApi.java
+++ b/src/main/java/com/soptie/server/api/controller/MemberApi.java
@@ -17,6 +17,7 @@ import com.soptie.server.api.controller.dto.request.member.CreateProfileRequest;
 import com.soptie.server.api.controller.dto.response.SuccessResponse;
 import com.soptie.server.api.controller.dto.response.member.GetHomeInfoResponse;
 import com.soptie.server.api.controller.dto.response.member.GiveMemberCottonResponse;
+import com.soptie.server.api.controller.dto.response.member.MemberProfileResponse;
 import com.soptie.server.api.controller.generic.SuccessMessage;
 import com.soptie.server.domain.member.CottonType;
 import com.soptie.server.domain.member.MemberService;
@@ -60,4 +61,13 @@ public class MemberApi implements MemberApiDocs {
 		val response = memberService.getMemberHomeInfo(memberId);
 		return SuccessResponse.success(SuccessMessage.GET_MEMBER_HOME.getMessage(), response);
 	}
+
+	@ResponseStatus(HttpStatus.OK)
+	@GetMapping("/profile")
+	public SuccessResponse<MemberProfileResponse> getMemberProfile(Principal principal) {
+		val memberId = Long.parseLong(principal.getName());
+		val response = memberService.getMemberProfile(memberId);
+		return SuccessResponse.success(SuccessMessage.GET_MEMBER_PROFILE.getMessage(), response);
+	}
+
 }

--- a/src/main/java/com/soptie/server/api/controller/docs/MemberApiDocs.java
+++ b/src/main/java/com/soptie/server/api/controller/docs/MemberApiDocs.java
@@ -21,7 +21,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "members", description = "회원 API")
+@Tag(name = "[Member] 회원 API", description = "회원 관련 api 입니다.")
 public interface MemberApiDocs {
 
 	@Operation(

--- a/src/main/java/com/soptie/server/api/controller/docs/MemberApiDocs.java
+++ b/src/main/java/com/soptie/server/api/controller/docs/MemberApiDocs.java
@@ -10,6 +10,7 @@ import com.soptie.server.api.controller.dto.response.ErrorResponse;
 import com.soptie.server.api.controller.dto.response.SuccessResponse;
 import com.soptie.server.api.controller.dto.response.member.GetHomeInfoResponse;
 import com.soptie.server.api.controller.dto.response.member.GiveMemberCottonResponse;
+import com.soptie.server.api.controller.dto.response.member.MemberProfileResponse;
 import com.soptie.server.domain.member.CottonType;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -116,6 +117,24 @@ public interface MemberApiDocs {
 				content = @Content(schema = @Schema(implementation = ErrorResponse.class)))}
 	)
 	SuccessResponse<GetHomeInfoResponse> getMemberHomeInfo(
+		@Parameter(hidden = true) Principal principal
+	);
+
+	@Operation(
+		summary = "회원 정보 조회",
+		description = "회원의 정보를 조회합니다.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "성공"),
+			@ApiResponse(
+				responseCode = "4xx",
+				description = "클라이언트(요청) 오류",
+				content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+			@ApiResponse(
+				responseCode = "500",
+				description = "서버 내부 오류",
+				content = @Content(schema = @Schema(implementation = ErrorResponse.class)))}
+	)
+	SuccessResponse<MemberProfileResponse> getMemberProfile(
 		@Parameter(hidden = true) Principal principal
 	);
 }

--- a/src/main/java/com/soptie/server/api/controller/dto/response/member/MemberProfileResponse.java
+++ b/src/main/java/com/soptie/server/api/controller/dto/response/member/MemberProfileResponse.java
@@ -14,7 +14,7 @@ public record MemberProfileResponse(
 	LocalDateTime createdAt
 ) {
 
-	public static MemberProfileResponse of(Member member) {
+	public static MemberProfileResponse from(Member member) {
 		return MemberProfileResponse.builder()
 			.createdAt(member.getCreatedAt())
 			.build();

--- a/src/main/java/com/soptie/server/api/controller/dto/response/member/MemberProfileResponse.java
+++ b/src/main/java/com/soptie/server/api/controller/dto/response/member/MemberProfileResponse.java
@@ -1,0 +1,22 @@
+package com.soptie.server.api.controller.dto.response.member;
+
+import java.time.LocalDateTime;
+
+import com.soptie.server.domain.member.Member;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record MemberProfileResponse(
+	@Schema(description = "회원가입 일자", example = "yyyy-MM-dd:HH:mm")
+	LocalDateTime createdAt
+) {
+
+	public static MemberProfileResponse of(Member member) {
+		return MemberProfileResponse.builder()
+			.createdAt(member.getCreatedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/soptie/server/api/controller/dto/response/member/MemberProfileResponse.java
+++ b/src/main/java/com/soptie/server/api/controller/dto/response/member/MemberProfileResponse.java
@@ -10,7 +10,7 @@ import lombok.Builder;
 
 @Builder(access = AccessLevel.PRIVATE)
 public record MemberProfileResponse(
-	@Schema(description = "회원가입 일자", example = "yyyy-MM-dd:HH:mm")
+	@Schema(description = "회원가입 일자", example = "2024-08-28T15:34:05.272309")
 	LocalDateTime createdAt
 ) {
 

--- a/src/main/java/com/soptie/server/api/controller/generic/SuccessMessage.java
+++ b/src/main/java/com/soptie/server/api/controller/generic/SuccessMessage.java
@@ -14,6 +14,7 @@ public enum SuccessMessage {
 
 	/* member */
 	CREATE_MEMBER_PROFILE("회원 프로필 등록 성공"),
+	GET_MEMBER_PROFILE("회원 프로필 조회 성공"),
 	GIVE_COTTON("솜뭉치 주기 성공"),
 	GET_MEMBER_HOME("홈화면 정보 조회 성공"),
 

--- a/src/main/java/com/soptie/server/domain/member/Member.java
+++ b/src/main/java/com/soptie/server/domain/member/Member.java
@@ -1,5 +1,7 @@
 package com.soptie.server.domain.member;
 
+import java.time.LocalDateTime;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,6 +15,7 @@ public class Member {
 	private Social socialInfo;
 	private String refreshToken;
 	private MemberCotton cottonInfo;
+	private LocalDateTime createdAt;
 
 	public Member(SocialType socialType, String socialId) {
 		this.socialInfo = new Social(socialType, socialId);

--- a/src/main/java/com/soptie/server/domain/member/MemberService.java
+++ b/src/main/java/com/soptie/server/domain/member/MemberService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.soptie.server.api.controller.dto.request.member.CreateProfileRequest;
 import com.soptie.server.api.controller.dto.response.member.GetHomeInfoResponse;
 import com.soptie.server.api.controller.dto.response.member.GiveMemberCottonResponse;
+import com.soptie.server.api.controller.dto.response.member.MemberProfileResponse;
 import com.soptie.server.common.exception.ExceptionCode;
 import com.soptie.server.common.exception.SoftieException;
 import com.soptie.server.domain.conversation.Conversation;
@@ -76,5 +77,10 @@ public class MemberService {
 			val doll = dollAdapter.findByType(dollType);
 			memberDollAdapter.save(new MemberDoll(name, dollType, memberId, doll.getId()));
 		}
+	}
+
+	public MemberProfileResponse getMemberProfile(long memberId) {
+		val member = memberAdapter.findById(memberId);
+		return MemberProfileResponse.of(member);
 	}
 }

--- a/src/main/java/com/soptie/server/domain/member/MemberService.java
+++ b/src/main/java/com/soptie/server/domain/member/MemberService.java
@@ -81,6 +81,6 @@ public class MemberService {
 
 	public MemberProfileResponse getMemberProfile(long memberId) {
 		val member = memberAdapter.findById(memberId);
-		return MemberProfileResponse.of(member);
+		return MemberProfileResponse.from(member);
 	}
 }

--- a/src/main/java/com/soptie/server/persistence/entity/MemberEntity.java
+++ b/src/main/java/com/soptie/server/persistence/entity/MemberEntity.java
@@ -56,6 +56,7 @@ public class MemberEntity extends BaseEntity {
 			.socialInfo(toSocialInfo())
 			.refreshToken(this.refreshToken)
 			.cottonInfo(toCottonInfo())
+			.createdAt(this.createdAt)
 			.build();
 	}
 


### PR DESCRIPTION
## ✨ Related Issue
- close #354 
  <br/>

## 📝 기능 구현 명세
- 회원 정보를 조회하는 API 개발
- 확장성을 위해 회원의 정보를 조회하는 API를 추가하고, 이번 스프린트에서 필요한 회원가입일자(createdAt)만 우선 포함했습니다.

## 🐥 추가적인 언급 사항
- #353 PR 머지 후 리뷰를 진행해주세요. (중복 내용 포함)