### PR TITLE
[FIX] 메모 생성 및 캘린더 조회

### DIFF
--- a/src/main/java/com/soptie/server/api/controller/dto/response/calendar/DateHistoryResponse.java
+++ b/src/main/java/com/soptie/server/api/controller/dto/response/calendar/DateHistoryResponse.java
@@ -91,8 +91,8 @@ public record DateHistoryResponse(
 			final List<MissionHistory> missions
 		) {
 			return Stream.concat(
-				routines.stream().map(HistoryResponse::createRoutines),
-				missions.stream().map(HistoryResponse::createMissions)
+				missions.stream().map(HistoryResponse::createMissions),
+				routines.stream().map(HistoryResponse::createRoutines)
 			).toList();
 		}
 

--- a/src/main/java/com/soptie/server/api/controller/dto/response/calendar/DateHistoryResponse.java
+++ b/src/main/java/com/soptie/server/api/controller/dto/response/calendar/DateHistoryResponse.java
@@ -3,6 +3,8 @@ package com.soptie.server.api.controller.dto.response.calendar;
 import static lombok.AccessLevel.PRIVATE;
 
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -54,13 +56,16 @@ public record DateHistoryResponse(
 	) {
 		return Stream.concat(routines.keySet().stream(), missions.keySet().stream())
 			.distinct()
+			.sorted(Comparator.comparingInt(Theme::getSequence))
 			.collect(Collectors.toMap(
 				theme -> theme,
 				theme -> HistoriesResponse.of(
 					theme,
 					routines.getOrDefault(theme, Collections.emptyList()),
 					missions.getOrDefault(theme, Collections.emptyList())
-				)
+				),
+				(existing, replacement) -> existing,
+				LinkedHashMap::new
 			));
 	}
 

--- a/src/main/java/com/soptie/server/common/support/ValueConfig.java
+++ b/src/main/java/com/soptie/server/common/support/ValueConfig.java
@@ -51,6 +51,7 @@ public class ValueConfig {
 	public static final String MEMBER_DOLL_CONDITION = "^[ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z]{1,10}$";
 	public static final long MEMBER_HAS_NOT_CHALLENGE = 0;
 	public static final long MEMBER_HAS_NOT_MEMO = 0;
+	public static final int MEMO_MAX_LENGTH = 100;
 
 	@PostConstruct
 	protected void init() {

--- a/src/main/java/com/soptie/server/domain/memo/MemoService.java
+++ b/src/main/java/com/soptie/server/domain/memo/MemoService.java
@@ -52,6 +52,9 @@ public class MemoService {
 		if (hasNoRoutineHistory(memberId, request) && hasNoMissionHistory(memberId, request)) {
 			throw new SoftieException(ExceptionCode.BAD_REQUEST, "해당 날짜에 루틴 및 미션 달성 내역이 존재하지 않습니다.");
 		}
+		if (memoAdapter.isExistByMemberIdAndAchievedDate(memberId, request.achievedDate())) {
+			throw new SoftieException(ExceptionCode.BAD_REQUEST, "해당 날짜에 이미 메모가 존재합니다.");
+		}
 	}
 
 	private boolean hasNoRoutineHistory(final long memberId, final CreateMemoRequest request) {

--- a/src/main/java/com/soptie/server/persistence/adapter/MemoAdapter.java
+++ b/src/main/java/com/soptie/server/persistence/adapter/MemoAdapter.java
@@ -20,6 +20,10 @@ public class MemoAdapter {
 
 	private final MemoRepository memoRepository;
 
+	public boolean isExistByMemberIdAndAchievedDate(final long memberId, final LocalDate achievedDate) {
+		return memoRepository.findFirstByMemberIdAndAchievedDate(memberId, achievedDate).isPresent();
+	}
+
 	public Memo save(final LocalDate achievedDate, final String content, final Member member) {
 		return memoRepository.save(new MemoEntity(achievedDate, content, member)).toDomain();
 	}

--- a/src/main/java/com/soptie/server/persistence/entity/MemoEntity.java
+++ b/src/main/java/com/soptie/server/persistence/entity/MemoEntity.java
@@ -1,5 +1,7 @@
 package com.soptie.server.persistence.entity;
 
+import static com.soptie.server.common.support.ValueConfig.MEMO_MAX_LENGTH;
+
 import java.time.LocalDate;
 
 import com.soptie.server.domain.member.Member;
@@ -17,7 +19,7 @@ import lombok.NoArgsConstructor;
 public class MemoEntity extends BaseEntity {
 	@Column(nullable = false)
 	private LocalDate achievedDate;
-	@Column(nullable = false)
+	@Column(nullable = false, length = MEMO_MAX_LENGTH)
 	private String content;
 	@Column(nullable = false)
 	private long memberId;

--- a/src/main/java/com/soptie/server/persistence/repository/MemoRepository.java
+++ b/src/main/java/com/soptie/server/persistence/repository/MemoRepository.java
@@ -11,6 +11,8 @@ import org.springframework.data.repository.query.Param;
 import com.soptie.server.persistence.entity.MemoEntity;
 
 public interface MemoRepository extends JpaRepository<MemoEntity, Long> {
+	Optional<MemoEntity> findFirstByMemberIdAndAchievedDate(long memberId, LocalDate achievedDate);
+
 	Optional<MemoEntity> findByIdAndMemberId(long id, long memberId);
 
 	void deleteByIdAndMemberId(long id, long memberId);


### PR DESCRIPTION
## ✨ Related Issue
- close #362 
  <br/>

## 📝 기능 구현 명세
![image](https://github.com/user-attachments/assets/959dcb6c-9657-409a-b821-7db54d17625b)
- 메모 중복 생성 방지 (동일 날짜)

![image](https://github.com/user-attachments/assets/e6c28038-d9a6-4e07-8c06-c8fa8b7deee4)
- 캘린더 조회 시, 테마 순서로 정렬 및 도전 -> 데일리 순으로 전달

## 🐥 추가적인 언급 사항
- 저번에 리뷰 주신 Querydsl을 활용하는 방식도 적용하려 했으나 좀 더 공부하고 해보겠습니다.